### PR TITLE
Allow same action name on diffrent ActionClasses

### DIFF
--- a/src/alt.js
+++ b/src/alt.js
@@ -273,7 +273,7 @@ your own custom identifier for each store`
 
     return Object.keys(actions).reduce((obj, action) => {
       let constant = formatAsConstant(action)
-      let actionName = Symbol.for(`action ${action}`)
+      let actionName = Symbol.for(`action ${ActionsClass.name} ${action}`)
 
       // Wrap the action so we can provide a dispatch method
       let newAction = new ActionCreator(


### PR DESCRIPTION
without this there can be for example only one action named 'update'.
with this you can have multiple ActionClasses with same actions.

class UserActions {
	constructor() { this.generateActions('update'); }
}
module.exports = alt.createActions(UserActions);

class LinkActions {
	constructor() { this.generateActions('update'); }
}
module.exports = alt.createActions(LinkActions);