### PR TITLE
Adding a shorthand form of alt.createActions()

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,12 @@ var locationActions = alt.createActions(LocationActions)
 locationActions.updateLocation('South Lake Tahoe', 'California')
 ```
 
+There's even a shorthand for the shorthand if all you're doing is generating a list of actions
+
+```js
+var locationActions = alt.generateActions('updateLocation', 'updateCity', 'updateState', 'updateCountry')
+```
+
 ### Stores
 
 Stores are where you keep a part of your application's state. It's a singleton, holds your data, and is immutable.

--- a/dist/alt-with-runtime.js
+++ b/dist/alt-with-runtime.js
@@ -1,10 +1,9 @@
 "use strict";
 
 var Dispatcher = require("flux").Dispatcher;
+
 var EventEmitter = babelHelpers.interopRequire(require("eventemitter3"));
-
 var Symbol = babelHelpers.interopRequire(require("es-symbol"));
-
 var assign = babelHelpers.interopRequire(require("object-assign"));
 
 var now = Date.now();
@@ -48,6 +47,7 @@ var getInternalMethods = function (obj, excluded) {
 var AltStore = (function () {
   function AltStore(dispatcher, state) {
     var _this5 = this;
+
     babelHelpers.classCallCheck(this, AltStore);
 
     this[EE] = new EventEmitter();
@@ -100,7 +100,6 @@ var AltStore = (function () {
       configurable: true
     }
   });
-
   return AltStore;
 })();
 
@@ -123,7 +122,6 @@ var ActionCreator = (function () {
       configurable: true
     }
   });
-
   return ActionCreator;
 })();
 
@@ -154,6 +152,7 @@ var StoreMixin = {
 
   bindActions: function bindActions(actions) {
     var _this5 = this;
+
     Object.keys(actions).forEach(function (action) {
       var symbol = actions[action];
       var matchFirstCharacter = /./;
@@ -247,10 +246,12 @@ var Alt = (function () {
     createStore: {
       value: function createStore(StoreModel, iden) {
         var _this5 = this;
+
         var key = iden || StoreModel.displayName || StoreModel.name;
         // Creating a class here so we don't overload the provided store's
         // prototype with the mixin behaviour and I'm extending from StoreModel
         // so we can inherit any extensions from the provided store.
+
         var Store = (function (StoreModel) {
           function Store() {
             babelHelpers.classCallCheck(this, Store);
@@ -261,7 +262,6 @@ var Alt = (function () {
           }
 
           babelHelpers.inherits(Store, StoreModel);
-
           return Store;
         })(StoreModel);
 
@@ -289,10 +289,31 @@ var Alt = (function () {
       writable: true,
       configurable: true
     },
+    generateActions: {
+      value: function generateActions() {
+        for (var _len = arguments.length, actionNames = Array(_len), _key = 0; _key < _len; _key++) {
+          actionNames[_key] = arguments[_key];
+        }
+
+        var ActionsClass = function ActionsClass() {
+          var _ref;
+
+          babelHelpers.classCallCheck(this, ActionsClass);
+
+          (_ref = this).generateActions.apply(_ref, actionNames);
+        };
+
+        return this.createActions(ActionsClass);
+      },
+      writable: true,
+      configurable: true
+    },
     createActions: {
       value: function createActions(ActionsClass) {
         var _this5 = this;
+
         var exportObj = arguments[1] === undefined ? {} : arguments[1];
+
         var actions = assign({}, getInternalMethods(ActionsClass.prototype, builtInProto));
         var key = ActionsClass.displayName || ActionsClass.name;
 
@@ -304,7 +325,6 @@ var Alt = (function () {
           }
 
           babelHelpers.inherits(ActionsGenerator, ActionsClass);
-
           babelHelpers.prototypeProperties(ActionsGenerator, null, {
             generateActions: {
               value: function generateActions() {
@@ -327,7 +347,6 @@ var Alt = (function () {
               configurable: true
             }
           });
-
           return ActionsGenerator;
         })(ActionsClass);
 
@@ -449,7 +468,6 @@ var Alt = (function () {
       configurable: true
     }
   });
-
   return Alt;
 })();
 

--- a/dist/alt.js
+++ b/dist/alt.js
@@ -11,6 +11,7 @@ var _prototypeProperties = function (child, staticProps, instanceProps) { if (st
 var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } };
 
 var Dispatcher = require("flux").Dispatcher;
+
 var EventEmitter = _interopRequire(require("eventemitter3"));
 
 var Symbol = _interopRequire(require("es-symbol"));
@@ -58,6 +59,7 @@ var getInternalMethods = function (obj, excluded) {
 var AltStore = (function () {
   function AltStore(dispatcher, state) {
     var _this5 = this;
+
     _classCallCheck(this, AltStore);
 
     this[EE] = new EventEmitter();
@@ -164,6 +166,7 @@ var StoreMixin = {
 
   bindActions: function bindActions(actions) {
     var _this5 = this;
+
     Object.keys(actions).forEach(function (action) {
       var symbol = actions[action];
       var matchFirstCharacter = /./;
@@ -257,10 +260,12 @@ var Alt = (function () {
     createStore: {
       value: function createStore(StoreModel, iden) {
         var _this5 = this;
+
         var key = iden || StoreModel.displayName || StoreModel.name;
         // Creating a class here so we don't overload the provided store's
         // prototype with the mixin behaviour and I'm extending from StoreModel
         // so we can inherit any extensions from the provided store.
+
         var Store = (function (StoreModel) {
           function Store() {
             _classCallCheck(this, Store);
@@ -299,10 +304,31 @@ var Alt = (function () {
       writable: true,
       configurable: true
     },
+    generateActions: {
+      value: function generateActions() {
+        for (var _len = arguments.length, actionNames = Array(_len), _key = 0; _key < _len; _key++) {
+          actionNames[_key] = arguments[_key];
+        }
+
+        var ActionsClass = function ActionsClass() {
+          var _ref;
+
+          _classCallCheck(this, ActionsClass);
+
+          (_ref = this).generateActions.apply(_ref, actionNames);
+        };
+
+        return this.createActions(ActionsClass);
+      },
+      writable: true,
+      configurable: true
+    },
     createActions: {
       value: function createActions(ActionsClass) {
         var _this5 = this;
+
         var exportObj = arguments[1] === undefined ? {} : arguments[1];
+
         var actions = assign({}, getInternalMethods(ActionsClass.prototype, builtInProto));
         var key = ActionsClass.displayName || ActionsClass.name;
 

--- a/src/alt.js
+++ b/src/alt.js
@@ -253,16 +253,17 @@ your own custom identifier for each store`
     return this.stores[key]
   }
 
-  createActions(ActionsClass, exportObj = {}) {
-    if (ActionsClass instanceof Array) {
-      let actions = ActionsClass
-      ActionsClass = class DefaultActionsClass {
-        constructor() {
-          this.generateActions(...actions)
-        }
+  generateActions(...actionNames) {
+    class ActionsClass {
+      constructor() {
+        this.generateActions(...actionNames)
       }
     }
 
+    return this.createActions(ActionsClass)
+  }
+
+  createActions(ActionsClass, exportObj = {}) {
     let actions = assign(
       {},
       getInternalMethods(ActionsClass.prototype, builtInProto)

--- a/src/alt.js
+++ b/src/alt.js
@@ -254,6 +254,15 @@ your own custom identifier for each store`
   }
 
   createActions(ActionsClass, exportObj = {}) {
+    if (ActionsClass instanceof Array) {
+      let actions = ActionsClass
+      ActionsClass = class DefaultActionsClass {
+        constructor() {
+          this.generateActions(...actions)
+        }
+      }
+    }
+
     let actions = assign(
       {},
       getInternalMethods(ActionsClass.prototype, builtInProto)

--- a/test/index.js
+++ b/test/index.js
@@ -56,6 +56,8 @@ class MyActions {
 let myActions = {}
 alt.createActions(MyActions, myActions)
 
+let myShorthandActions = alt.createActions(["actionOne", "actionTwo"])
+
 class MyStore {
   constructor() {
     let myActionsInst = this.alt.getActions('myActions')
@@ -300,6 +302,8 @@ let tests = {
     assert.equal(typeof myActions.updateTwo, 'function', 'prototype defined actions exist')
     assert.equal(typeof myActions.updateThree, 'function', 'prototype defined actions exist')
     assert.equal(myActions.updateTwo.length, 2, 'actions can have > 1 arity')
+    assert.equal(typeof myShorthandActions.actionOne, 'function', 'action created with shorthand createActions exists')
+    assert.equal(typeof myShorthandActions.actionTwo, 'function', 'other action created with shorthand createActions exists')
   },
 
   'existence of constants'() {

--- a/test/index.js
+++ b/test/index.js
@@ -56,7 +56,7 @@ class MyActions {
 let myActions = {}
 alt.createActions(MyActions, myActions)
 
-let myShorthandActions = alt.createActions(["actionOne", "actionTwo"])
+let myShorthandActions = alt.generateActions("actionOne", "actionTwo")
 
 class MyStore {
   constructor() {


### PR DESCRIPTION
If you're not opposed to overloading the API, I think it could be useful to implement a shorthand for `alt.createActions()` that accepts an array of action names and automatically calls `this.generateActions()` for you in the constructor.

This pull request makes it so that the following two snippets are equivalent:

```javascript
var mySimpleActions = alt.createActions(['actionOne', 'actionTwo', 'actionThree'])
```
---
```javascript
class MySimpleActions {
  constructor() {
    this.generateActions('actionOne', 'actionTwo', 'actionThree')
  }
}

var mySimpleActions = alt.createActions(MySimpleActions)
```

Something to consider is that there would be an inconsistency between `generateActions` accepting multiple arguments and `createActions` accepting an array. Using a spread operator on the first argument of `createActions`  would be a little tricky because of the `exportObj` argument. Let me know your thoughts.