### PR TITLE
Fixing breaking change that prevented server side rendering when ListenerMixin was used.

### DIFF
--- a/dist/alt-with-runtime.js
+++ b/dist/alt-with-runtime.js
@@ -1,10 +1,9 @@
 "use strict";
 
 var Dispatcher = require("flux").Dispatcher;
+
 var EventEmitter = babelHelpers.interopRequire(require("eventemitter3"));
-
 var Symbol = babelHelpers.interopRequire(require("es-symbol"));
-
 var assign = babelHelpers.interopRequire(require("object-assign"));
 
 var now = Date.now();
@@ -48,6 +47,7 @@ var getInternalMethods = function (obj, excluded) {
 var AltStore = (function () {
   function AltStore(dispatcher, state) {
     var _this6 = this;
+
     babelHelpers.classCallCheck(this, AltStore);
 
     this[EE] = new EventEmitter();
@@ -100,7 +100,6 @@ var AltStore = (function () {
       configurable: true
     }
   });
-
   return AltStore;
 })();
 
@@ -123,7 +122,6 @@ var ActionCreator = (function () {
       configurable: true
     }
   });
-
   return ActionCreator;
 })();
 
@@ -154,6 +152,7 @@ var StoreMixin = {
 
   bindActions: function bindActions(actions) {
     var _this6 = this;
+
     Object.keys(actions).forEach(function (action) {
       var symbol = actions[action];
       var matchFirstCharacter = /./;
@@ -181,6 +180,7 @@ var StoreMixin = {
 
   bindListeners: function bindListeners(obj) {
     var _this6 = this;
+
     Object.keys(obj).forEach(function (methodName) {
       var symbol = obj[methodName];
       var listener = _this6[methodName];
@@ -267,10 +267,12 @@ var Alt = (function () {
     createStore: {
       value: function createStore(StoreModel, iden) {
         var _this6 = this;
+
         var key = iden || StoreModel.displayName || StoreModel.name;
         // Creating a class here so we don't overload the provided store's
         // prototype with the mixin behaviour and I'm extending from StoreModel
         // so we can inherit any extensions from the provided store.
+
         var Store = (function (StoreModel) {
           function Store() {
             babelHelpers.classCallCheck(this, Store);
@@ -281,7 +283,6 @@ var Alt = (function () {
           }
 
           babelHelpers.inherits(Store, StoreModel);
-
           return Store;
         })(StoreModel);
 
@@ -317,6 +318,7 @@ var Alt = (function () {
 
         var ActionsClass = function ActionsClass() {
           var _ref;
+
           babelHelpers.classCallCheck(this, ActionsClass);
 
           (_ref = this).generateActions.apply(_ref, actionNames);
@@ -330,7 +332,9 @@ var Alt = (function () {
     createActions: {
       value: function createActions(ActionsClass) {
         var _this6 = this;
+
         var exportObj = arguments[1] === undefined ? {} : arguments[1];
+
         var actions = assign({}, getInternalMethods(ActionsClass.prototype, builtInProto));
         var key = ActionsClass.displayName || ActionsClass.name;
 
@@ -342,7 +346,6 @@ var Alt = (function () {
           }
 
           babelHelpers.inherits(ActionsGenerator, ActionsClass);
-
           babelHelpers.prototypeProperties(ActionsGenerator, null, {
             generateActions: {
               value: function generateActions() {
@@ -365,7 +368,6 @@ var Alt = (function () {
               configurable: true
             }
           });
-
           return ActionsGenerator;
         })(ActionsClass);
 
@@ -487,7 +489,6 @@ var Alt = (function () {
       configurable: true
     }
   });
-
   return Alt;
 })();
 

--- a/dist/alt.js
+++ b/dist/alt.js
@@ -11,6 +11,7 @@ var _prototypeProperties = function (child, staticProps, instanceProps) { if (st
 var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } };
 
 var Dispatcher = require("flux").Dispatcher;
+
 var EventEmitter = _interopRequire(require("eventemitter3"));
 
 var Symbol = _interopRequire(require("es-symbol"));
@@ -58,6 +59,7 @@ var getInternalMethods = function (obj, excluded) {
 var AltStore = (function () {
   function AltStore(dispatcher, state) {
     var _this6 = this;
+
     _classCallCheck(this, AltStore);
 
     this[EE] = new EventEmitter();
@@ -164,6 +166,7 @@ var StoreMixin = {
 
   bindActions: function bindActions(actions) {
     var _this6 = this;
+
     Object.keys(actions).forEach(function (action) {
       var symbol = actions[action];
       var matchFirstCharacter = /./;
@@ -191,6 +194,7 @@ var StoreMixin = {
 
   bindListeners: function bindListeners(obj) {
     var _this6 = this;
+
     Object.keys(obj).forEach(function (methodName) {
       var symbol = obj[methodName];
       var listener = _this6[methodName];
@@ -277,10 +281,12 @@ var Alt = (function () {
     createStore: {
       value: function createStore(StoreModel, iden) {
         var _this6 = this;
+
         var key = iden || StoreModel.displayName || StoreModel.name;
         // Creating a class here so we don't overload the provided store's
         // prototype with the mixin behaviour and I'm extending from StoreModel
         // so we can inherit any extensions from the provided store.
+
         var Store = (function (StoreModel) {
           function Store() {
             _classCallCheck(this, Store);
@@ -327,6 +333,7 @@ var Alt = (function () {
 
         var ActionsClass = function ActionsClass() {
           var _ref;
+
           _classCallCheck(this, ActionsClass);
 
           (_ref = this).generateActions.apply(_ref, actionNames);
@@ -340,7 +347,9 @@ var Alt = (function () {
     createActions: {
       value: function createActions(ActionsClass) {
         var _this6 = this;
+
         var exportObj = arguments[1] === undefined ? {} : arguments[1];
+
         var actions = assign({}, getInternalMethods(ActionsClass.prototype, builtInProto));
         var key = ActionsClass.displayName || ActionsClass.name;
 

--- a/mixins/ListenerMixin.js
+++ b/mixins/ListenerMixin.js
@@ -1,7 +1,7 @@
 var Subscribe = require('./Subscribe')
 
 var ListenerMixin = {
-  componentDidMount: function () {
+  componentWillMount: function () {
     Subscribe.create(this)
   },
 

--- a/test/index.js
+++ b/test/index.js
@@ -897,7 +897,7 @@ let tests = {
     let handler = () => { }
 
     // set it up
-    ListenerMixin.componentDidMount()
+    ListenerMixin.componentWillMount()
 
     ListenerMixin.listenTo(myStore, handler)
 


### PR DESCRIPTION
Changing lifecycle hook for Listener Mixin to Component Will Mount so that it functions identically between server rendering and client rendering.