### PR TITLE
Updated .waitFor() to allow passing store instances instead of tokens. 

### DIFF
--- a/dist/alt-with-runtime.js
+++ b/dist/alt-with-runtime.js
@@ -206,11 +206,21 @@ var StoreMixin = {
     });
   },
 
-  waitFor: function waitFor(tokens) {
-    if (!tokens) {
+  waitFor: function waitFor(sources) {
+    if (!sources) {
       throw new ReferenceError("Dispatch tokens not provided");
     }
-    tokens = Array.isArray(tokens) ? tokens : [tokens];
+
+    if (arguments.length === 1) {
+      sources = Array.isArray(sources) ? sources : [sources];
+    } else {
+      sources = Array.prototype.slice.call(arguments);
+    }
+
+    var tokens = sources.map(function (source) {
+      return source.dispatchToken || source;
+    });
+
     this.dispatcher.waitFor(tokens);
   }
 };

--- a/dist/alt.js
+++ b/dist/alt.js
@@ -220,11 +220,21 @@ var StoreMixin = {
     });
   },
 
-  waitFor: function waitFor(tokens) {
-    if (!tokens) {
+  waitFor: function waitFor(sources) {
+    if (!sources) {
       throw new ReferenceError("Dispatch tokens not provided");
     }
-    tokens = Array.isArray(tokens) ? tokens : [tokens];
+
+    if (arguments.length === 1) {
+      sources = Array.isArray(sources) ? sources : [sources];
+    } else {
+      sources = Array.prototype.slice.call(arguments);
+    }
+
+    var tokens = sources.map(function (source) {
+      return source.dispatchToken || source;
+    });
+
     this.dispatcher.waitFor(tokens);
   }
 };

--- a/src/alt.js
+++ b/src/alt.js
@@ -184,10 +184,10 @@ const StoreMixin = {
     if (arguments.length === 1) {
       sources = Array.isArray(sources) ? sources : [sources]
     } else {
-      sources = Array.prototype.slice.call( arguments)
+      sources = Array.prototype.slice.call(arguments)
     }
 
-    let tokens = sources.map(( source)=>{
+    let tokens = sources.map((source) => {
       return source.dispatchToken || source
     })
 

--- a/src/alt.js
+++ b/src/alt.js
@@ -177,7 +177,7 @@ const StoreMixin = {
   },
 
   waitFor(sources) {
-    if (! sources) {
+    if (!sources) {
       throw new ReferenceError('Dispatch tokens not provided')
     }
 

--- a/src/alt.js
+++ b/src/alt.js
@@ -176,11 +176,21 @@ const StoreMixin = {
     })
   },
 
-  waitFor(tokens) {
-    if (!tokens) {
+  waitFor(sources) {
+    if (! sources) {
       throw new ReferenceError('Dispatch tokens not provided')
     }
-    tokens = Array.isArray(tokens) ? tokens : [tokens]
+
+    if (arguments.length === 1) {
+      sources = Array.isArray(sources) ? sources : [sources]
+    } else {
+      sources = Array.prototype.slice.call( arguments)
+    }
+
+    let tokens = sources.map(( source)=>{
+      return source.dispatchToken || source
+    })
+
     this.dispatcher.waitFor(tokens)
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -49,6 +49,7 @@ class MyActions {
   updateThree(a, b, c) {
     this.dispatch({ a, b, c })
   }
+
 }
 
 let myActions = {}
@@ -208,6 +209,19 @@ class LifeCycleStore {
 
 let lifecycleStore = alt.createStore(LifeCycleStore)
 
+class ThirdStore {
+  constructor() {
+    this.bindAction(myActions.updateName, this.onUpdateName)
+  }
+
+  onUpdateName() {
+    this.waitFor( myStore, secondStore) // Not referencing dispatchToken!
+    this.name= secondStore.getState().name +'3'
+  }
+}
+
+let thirdStore= alt.createStore(ThirdStore)
+
 // Alt instances...
 
 class AltInstance extends Alt {
@@ -345,6 +359,7 @@ let tests = {
     assert.equal(myStore.getState().name, 'bear', 'action was called, state was updated properly')
     assert.equal(myStore.getState().calledInternal, false, 'internal method has not been called')
     assert.equal(secondStore.getState().name, 'bear', 'second store gets its value from myStore')
+    assert.equal(thirdStore.getState().name, 'bear3', 'third store gets its value from secondStore, adds 3')
   },
 
   'calling internal methods'() {

--- a/test/index.js
+++ b/test/index.js
@@ -215,12 +215,12 @@ class ThirdStore {
   }
 
   onUpdateName() {
-    this.waitFor( myStore, secondStore) // Not referencing dispatchToken!
-    this.name= secondStore.getState().name +'3'
+    this.waitFor(myStore, secondStore) // Not referencing dispatchToken!
+    this.name = secondStore.getState().name + '3'
   }
 }
 
-let thirdStore= alt.createStore(ThirdStore)
+let thirdStore = alt.createStore(ThirdStore)
 
 // Alt instances...
 


### PR DESCRIPTION
Will also accept multiple params instead of only an array of items. Backwards compatible with Facebook's version of waitFor().

As discussed in #38