### PR TITLE
Extract function name from source as a fallback to support IE

### DIFF
--- a/dist/alt-with-runtime.js
+++ b/dist/alt-with-runtime.js
@@ -27,6 +27,21 @@ var formatAsConstant = function (name) {
   }).toUpperCase();
 };
 
+var getFunctionName = function (aFunction) {
+  // Function.prototype.name is available
+  if (aFunction.name) {
+    return aFunction.name;
+  }
+
+  // Extract the function name from its source
+  var match = aFunction.toString().match(/^function\s*([^\s(]+)/);
+  if (match) {
+    return match[1];
+  }
+
+  return undefined;
+};
+
 /* istanbul ignore next */
 function NoopClass() {}
 
@@ -286,7 +301,7 @@ var Alt = (function () {
         var saveStore = arguments[2] === undefined ? true : arguments[2];
 
         var storeInstance = undefined;
-        var key = iden || StoreModel.name || StoreModel.displayName || "";
+        var key = iden || StoreModel.displayName || getFunctionName(StoreModel) || "";
 
         if (saveStore && (this.stores[key] || !key)) {
           /* istanbul ignore else */

--- a/dist/alt.js
+++ b/dist/alt.js
@@ -39,6 +39,21 @@ var formatAsConstant = function (name) {
   }).toUpperCase();
 };
 
+var getFunctionName = function (aFunction) {
+  // Function.prototype.name is available
+  if (aFunction.name) {
+    return aFunction.name;
+  }
+
+  // Extract the function name from its source
+  var match = aFunction.toString().match(/^function\s*([^\s(]+)/);
+  if (match) {
+    return match[1];
+  }
+
+  return undefined;
+};
+
 /* istanbul ignore next */
 function NoopClass() {}
 
@@ -300,7 +315,7 @@ var Alt = (function () {
         var saveStore = arguments[2] === undefined ? true : arguments[2];
 
         var storeInstance = undefined;
-        var key = iden || StoreModel.name || StoreModel.displayName || "";
+        var key = iden || StoreModel.displayName || getFunctionName(StoreModel) || "";
 
         if (saveStore && (this.stores[key] || !key)) {
           /* istanbul ignore else */

--- a/src/alt.js
+++ b/src/alt.js
@@ -24,6 +24,21 @@ const formatAsConstant = (name) => {
   }).toUpperCase()
 }
 
+const getFunctionName = (aFunction) => {
+  // Function.prototype.name is available
+  if (aFunction.name) {
+    return aFunction.name
+  }
+
+  // Extract the function name from its source
+  const match = aFunction.toString().match(/^function\s*([^\s(]+)/)
+  if (match) {
+    return match[1];
+  }
+
+  return undefined;
+}
+
 /* istanbul ignore next */
 function NoopClass() { }
 
@@ -249,7 +264,7 @@ class Alt {
 
   createStore(StoreModel, iden, saveStore = true) {
     let storeInstance
-    let key = iden || StoreModel.name || StoreModel.displayName || ''
+    let key = iden || StoreModel.displayName || getFunctionName(StoreModel) || ''
 
     if (saveStore && (this.stores[key] || !key)) {
       /* istanbul ignore else */

--- a/test/index.js
+++ b/test/index.js
@@ -292,6 +292,25 @@ let tests = {
     assert.equal(typeof myStore.emit, 'undefined', 'event emitter methods not present')
   },
 
+  'store name extraction'() {
+    let hiddenName = "hiddenName"
+    // IIFE is needed since babel will take the variable name as a function name
+    let storeModelWithoutName = (function() { return function () {} })()
+
+    // When no name can be found, the store will have the name ''
+    let storeWithoutName = alt.createStore(storeModelWithoutName)
+    assert.notEqual(alt.stores[''], undefined)
+
+    // override toString so that a name can be extracted by using the source
+    // of the function
+    storeModelWithoutName.toString = function() {
+      return "function " + hiddenName + "() {}"
+    }
+
+    let storeWithHiddenName = alt.createStore(storeModelWithoutName)
+    assert.notEqual(alt.stores[hiddenName], undefined)
+  },
+
   'store external methods'() {
     assert.equal(typeof myStore.externalMethod, 'function', 'static methods are made available')
     assert.equal(myStore.externalMethod(), true, 'static methods return proper result')


### PR DESCRIPTION
Unfortunately, Internet Explorer (I know, I know...) doesn't support `Function.prototype.name`, yet (and I think other browsers are lacking it, as well. See [here](http://kangax.github.io/compat-table/es6/#function_name_property)). I can understand if you don't want to support older technologies and want to delegate this work to transpilers and polyfills. But in this case, it was quite an easy fix and now it works. So, I think it should be worth considering to merge this :)

I reordered the priority of the potential name sources a little bit. I changed `StoreModel.displayName` and `StoreModel.name` which made it more clean to refactor the extraction of the function name into an own function. Additionally, it makes more sense to prioritize the optional `displayName` property over the standard function name, I think.

By the way: The chat example works in IE because store names were explicitly passed to `alt.createStore` and the TodoMVC example worked because there is only one store and `undefined` is taken as the store name. As soon as you add another store, it will also get `undefined` as a name which breaks alt.