### PR TITLE
Enable browser builds.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,13 +6,7 @@
     "Josh Perez <josh@goatslacker.com>"
   ],
   "description": "Alt is a flux implementation that is small (~4.3kb & 400 LOC), well tested, terse, insanely flexible, and forward thinking.",
-  "main": "dist/alt.js",
-  "dependencies": {
-    "es-symbol": "^1.0.1",
-    "eventemitter3": "^0.1.6",
-    "flux": "^2.0.1",
-    "object-assign": "^2.0.0"
-  },
+  "main": "dist/alt-browser.js",
   "devDependencies": {
     "babel": "^4.0.1",
     "coveralls": "^2.11.2",

--- a/dist/alt-browser-with-addons.js
+++ b/dist/alt-browser-with-addons.js
@@ -977,19 +977,6 @@ Alt.addons = {
   makeFinalStore: makeFinalStore
 };
 
-Alt.mixins = {
-  ReactStateMagicMixin: ReactStateMagicMixin,
-  ListenerMixin: ListenerMixin,
-  FluxyMixin: FluxyMixin
-};
-
-Alt.utils = {
-  Subscribe: Subscribe,
-  ActionListeners: ActionListeners,
-  DispatcherRecorder: DispatcherRecorder,
-  makeFinalStore: makeFinalStore
-};
-
 module.exports = Alt;
 
 },{"../mixins/FluxyMixin":1,"../mixins/ListenerMixin":2,"../mixins/ReactStateMagicMixin":3,"../mixins/Subscribe":4,"../utils/ActionListeners":13,"../utils/DispatcherRecorder":14,"../utils/makeFinalStore":15,"./alt":12}],12:[function(require,module,exports){

--- a/dist/alt-browser-with-addons.js
+++ b/dist/alt-browser-with-addons.js
@@ -953,11 +953,11 @@ var _interopRequire = function (obj) { return obj && obj.__esModule ? obj["defau
 
 var Alt = _interopRequire(require("./alt"));
 
-var ReactStateMagicMixin = _interopRequire(require("../mixins/ReactStateMagicMixin"));
+var FluxyMixin = _interopRequire(require("../mixins/FluxyMixin"));
 
 var ListenerMixin = _interopRequire(require("../mixins/ListenerMixin"));
 
-var FluxyMixin = _interopRequire(require("../mixins/FluxyMixin"));
+var ReactStateMagicMixin = _interopRequire(require("../mixins/ReactStateMagicMixin"));
 
 var Subscribe = _interopRequire(require("../mixins/Subscribe"));
 
@@ -968,13 +968,13 @@ var DispatcherRecorder = _interopRequire(require("../utils/DispatcherRecorder"))
 var makeFinalStore = _interopRequire(require("../utils/makeFinalStore"));
 
 Alt.addons = {
-  ReactStateMagicMixin: ReactStateMagicMixin,
-  ListenerMixin: ListenerMixin,
-  FluxyMixin: FluxyMixin,
-  Subscribe: Subscribe,
   ActionListeners: ActionListeners,
   DispatcherRecorder: DispatcherRecorder,
-  makeFinalStore: makeFinalStore
+  FluxyMixin: FluxyMixin,
+  ListenerMixin: ListenerMixin,
+  makeFinalStore: makeFinalStore,
+  ReactStateMagicMixin: ReactStateMagicMixin,
+  Subscribe: Subscribe
 };
 
 module.exports = Alt;

--- a/dist/alt-browser-with-addons.js
+++ b/dist/alt-browser-with-addons.js
@@ -1,0 +1,1694 @@
+(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.Alt = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+"use strict";
+
+/**
+ * This mixin lets you setup your listeners. It is similar to Fluxible's mixin.
+ *
+ * Usage:
+ *
+ * mixins: [FluxyMixin],
+ *
+ * statics: {
+ *   storeListeners: {
+ *     doFoo: FooStore,
+ *     doBar: BarStore
+ *   }
+ * },
+ *
+ * doFoo: function (storeState) {
+ *   this.setState({ foo: FooStore.getState() })
+ * },
+ *
+ * doBar: function (storeState) { },
+ *
+ * render: function () {
+ *   // state will be in the keys you provided
+ *   this.state.foo
+ * }
+ *
+ * ----
+ *
+ * You can also pass in an Array of stores to storeListeners:
+ *
+ * statics: {
+ *   storeListeners: [FooStore, BarStore]
+ * }
+ *
+ * Changes will then be passed to a function `onChange` which you will have
+ * to define:
+ *
+ * onChange() {
+ *   this.setState({
+ *     foo: FooStore.getState(),
+ *     bar: BarStore.getState()
+ *   })
+ * }
+ */
+var Subscribe = require("./Subscribe");
+
+var FluxyMixin = {
+  componentDidMount: function componentDidMount() {
+    Subscribe.create(this);
+
+    var stores = this.constructor.storeListeners;
+
+    if (Array.isArray(stores)) {
+      var handler = this.onChange;
+      if (!handler) {
+        throw new ReferenceError(handler + " should exist in your React component but is not defined");
+      }
+
+      stores.forEach(function (store) {
+        Subscribe.add(this, store, handler);
+      }, this);
+    } else {
+      Object.keys(stores).forEach(function (handler) {
+        if (!this[handler]) {
+          throw new ReferenceError(handler + " does not exist in your React component");
+        }
+
+        Subscribe.add(this, stores[handler], this[handler]);
+      }, this);
+    }
+  },
+
+  componentWillUnmount: function componentWillUnmount() {
+    Subscribe.destroy(this);
+  }
+};
+
+module.exports = FluxyMixin;
+
+},{"./Subscribe":4}],2:[function(require,module,exports){
+"use strict";
+
+var Subscribe = require("./Subscribe");
+
+var ListenerMixin = {
+  componentWillMount: function componentWillMount() {
+    Subscribe.create(this);
+  },
+
+  componentWillUnmount: function componentWillUnmount() {
+    Subscribe.destroy(this);
+  },
+
+  listenTo: function listenTo(store, handler) {
+    Subscribe.add(this, store, handler);
+  },
+
+  listenToMany: function listenToMany(stores, handler) {
+    stores.forEach(function (store) {
+      this.listenTo(store, handler);
+    }, this);
+  },
+
+  getListeners: function getListeners() {
+    return Subscribe.listeners(this);
+  }
+};
+
+module.exports = ListenerMixin;
+
+},{"./Subscribe":4}],3:[function(require,module,exports){
+"use strict";
+
+/**
+ * This mixin automatically sets the state for you based on the key you provide
+ *
+ * Usage:
+ *
+ * mixins: [ReactStateMagicMixin],
+ *
+ * statics: {
+ *   registerStores: {
+ *     foo: FooStore,
+ *     bar: BarStore
+ *   }
+ * },
+ *
+ * render: function () {
+ *   // state will be in the keys you provided
+ *   this.state.foo
+ *   this.state.bar
+ * }
+ *
+ * Alternatively:
+ *
+ * statics: {
+ *   registerStore: FooStore
+ * },
+ *
+ * render: function () {
+ *   // all of FooStore's state will be dumped into this.state
+ *   this.state
+ * }
+ */
+var Subscribe = require("./Subscribe");
+
+var ReactStateMagicMixin = {
+  getInitialState: function getInitialState() {
+    return this.getStateFromStores();
+  },
+
+  componentDidMount: function componentDidMount() {
+    Subscribe.create(this);
+
+    var stores = this.constructor.registerStores;
+
+    if (this.constructor.registerStore && this.constructor.registerStores) {
+      throw new ReferenceError("You are attempting to use `registerStore` and `registerStores` " + "pick one");
+    }
+
+    if (this.constructor.registerStore) {
+      Subscribe.add(this, this.constructor.registerStore, this.altSetState);
+    } else {
+      Object.keys(stores).forEach(function (formatter) {
+        Subscribe.add(this, stores[formatter], this.altSetState);
+      }, this);
+    }
+  },
+
+  componentWillUnmount: function componentWillUnmount() {
+    Subscribe.destroy(this);
+  },
+
+  getStateFromStores: function getStateFromStores() {
+    if (this.constructor.registerStore) {
+      return this.constructor.registerStore.getState();
+    }
+
+    var stores = this.constructor.registerStores;
+
+    return Object.keys(stores).reduce(function (obj, key) {
+      return (obj[key] = stores[key].getState(), obj);
+    }, {});
+  },
+
+  altSetState: function altSetState() {
+    this.setState(this.getStateFromStores());
+  }
+};
+
+module.exports = ReactStateMagicMixin;
+
+},{"./Subscribe":4}],4:[function(require,module,exports){
+"use strict";
+
+var Symbol = require("es-symbol");
+var MIXIN_REGISTRY = Symbol("alt store listeners");
+
+var Subscribe = {
+  create: function create(context) {
+    context[MIXIN_REGISTRY] = context[MIXIN_REGISTRY] || [];
+  },
+
+  add: function add(context, store, handler) {
+    context[MIXIN_REGISTRY].push({ store: store, handler: handler });
+    store.listen(handler);
+  },
+
+  destroy: function destroy(context) {
+    context[MIXIN_REGISTRY].forEach(function (x) {
+      x.store.unlisten(x.handler);
+    });
+    context[MIXIN_REGISTRY] = [];
+  },
+
+  listeners: function listeners(context) {
+    return context[MIXIN_REGISTRY];
+  }
+};
+
+module.exports = Subscribe;
+
+},{"es-symbol":5}],5:[function(require,module,exports){
+"use strict";
+
+var _defineProperty = function (obj, key, value) { return Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); };
+
+var globalSymbolRegistryList = {};
+
+// Aliases & Helpers
+var make = Object.create;
+var defProps = Object.defineProperties;
+var defProp = Object.defineProperty;
+var defValue = function (value) {
+  var opts = arguments[1] === undefined ? {} : arguments[1];
+  return {
+    value: value,
+    configurable: !!opts.c,
+    writable: !!opts.w,
+    enumerable: !!opts.e
+  };
+};
+var isSymbol = function (symbol) {
+  return symbol && symbol[xSymbol.toStringTag] === "Symbol";
+};
+
+var id = {};
+var uid = function (desc) {
+  desc = String(desc);
+  var x = "";
+  var i = 0;
+  while (id[desc + x]) {
+    x = i += 1;
+  }
+  id[desc + x] = 1;
+
+  var tag = "Symbol(" + desc + "" + x + ")";
+
+  // Make the symbols hidden to pre-es6 code
+  defProp(Object.prototype, tag, {
+    get: undefined,
+    set: function (value) {
+      defProp(this, tag, defValue(value, { c: true, w: true }));
+    },
+    configurable: true,
+    enumerable: false
+  });
+
+  return tag;
+};
+
+// The base symbol
+var SymbolProto = make(null);
+
+// 19.4.1.1
+function xSymbol(descString) {
+  if (this instanceof xSymbol) {
+    throw new TypeError("Symbol is not a constructor");
+  }
+
+  descString = descString === undefined ? "" : String(descString);
+
+  var tag = uid(descString);
+
+  return make(SymbolProto, {
+    __description__: defValue(descString),
+    __tag__: defValue(tag)
+  });
+}
+
+defProps(xSymbol, {
+  // 19.4.2.1
+  "for": defValue(function (key) {
+    var stringKey = String(key);
+
+    if (globalSymbolRegistryList[stringKey]) {
+      return globalSymbolRegistryList[stringKey];
+    }
+
+    var symbol = xSymbol(stringKey);
+    globalSymbolRegistryList[stringKey] = symbol;
+
+    return symbol;
+  }),
+
+  // 19.4.2.5
+  keyFor: defValue(function (sym) {
+    if (!isSymbol(sym)) {
+      throw new TypeError("" + sym + " is not a symbol");
+    }
+
+    for (var key in globalSymbolRegistryList) {
+      if (globalSymbolRegistryList[key] === sym) {
+        return globalSymbolRegistryList[key].__description__;
+      }
+    }
+  })
+});
+
+// 6.1.5.1
+defProps(xSymbol, {
+  hasInstance: defValue(xSymbol("hasInstance")),
+  isConcatSpreadable: defValue(xSymbol("isConcatSpreadable")),
+  iterator: defValue(xSymbol("iterator")),
+  match: defValue(xSymbol("match")),
+  replace: defValue(xSymbol("replace")),
+  search: defValue(xSymbol("search")),
+  species: defValue(xSymbol("species")),
+  split: defValue(xSymbol("split")),
+  toPrimitive: defValue(xSymbol("toPrimitive")),
+  toStringTag: defValue(xSymbol("toStringTag")),
+  unscopables: defValue(xSymbol("unscopables"))
+});
+
+// 19.4.3
+defProps(SymbolProto, {
+  constructor: defValue(xSymbol),
+
+  // 19.4.3.2
+  toString: defValue(function () {
+    return this.__tag__;
+  }),
+
+  // 19.4.3.3
+  valueOf: defValue(function () {
+    return "Symbol(" + this.__description__ + ")";
+  })
+});
+
+defProps(SymbolProto, (function () {
+  var _defProps = {};
+
+  _defineProperty(_defProps, xSymbol.toPrimitive, defValue(function (hint) {
+    return this;
+  }, { c: true }));
+
+  _defineProperty(_defProps, xSymbol.toStringTag, defValue("Symbol", { c: true }));
+
+  return _defProps;
+})());
+
+module.exports = typeof Symbol === "function" ? Symbol : xSymbol;
+// 19.4.3.4 XXX Does not follow spec.
+
+
+// 19.4.3.5
+
+
+},{}],6:[function(require,module,exports){
+'use strict';
+
+/**
+ * Representation of a single EventEmitter function.
+ *
+ * @param {Function} fn Event handler to be called.
+ * @param {Mixed} context Context for function execution.
+ * @param {Boolean} once Only emit once
+ * @api private
+ */
+function EE(fn, context, once) {
+  this.fn = fn;
+  this.context = context;
+  this.once = once || false;
+}
+
+/**
+ * Minimal EventEmitter interface that is molded against the Node.js
+ * EventEmitter interface.
+ *
+ * @constructor
+ * @api public
+ */
+function EventEmitter() { /* Nothing to set */ }
+
+/**
+ * Holds the assigned EventEmitters by name.
+ *
+ * @type {Object}
+ * @private
+ */
+EventEmitter.prototype._events = undefined;
+
+/**
+ * Return a list of assigned event listeners.
+ *
+ * @param {String} event The events that should be listed.
+ * @returns {Array}
+ * @api public
+ */
+EventEmitter.prototype.listeners = function listeners(event) {
+  if (!this._events || !this._events[event]) return [];
+  if (this._events[event].fn) return [this._events[event].fn];
+
+  for (var i = 0, l = this._events[event].length, ee = new Array(l); i < l; i++) {
+    ee[i] = this._events[event][i].fn;
+  }
+
+  return ee;
+};
+
+/**
+ * Emit an event to all registered event listeners.
+ *
+ * @param {String} event The name of the event.
+ * @returns {Boolean} Indication if we've emitted an event.
+ * @api public
+ */
+EventEmitter.prototype.emit = function emit(event, a1, a2, a3, a4, a5) {
+  if (!this._events || !this._events[event]) return false;
+
+  var listeners = this._events[event]
+    , len = arguments.length
+    , args
+    , i;
+
+  if ('function' === typeof listeners.fn) {
+    if (listeners.once) this.removeListener(event, listeners.fn, true);
+
+    switch (len) {
+      case 1: return listeners.fn.call(listeners.context), true;
+      case 2: return listeners.fn.call(listeners.context, a1), true;
+      case 3: return listeners.fn.call(listeners.context, a1, a2), true;
+      case 4: return listeners.fn.call(listeners.context, a1, a2, a3), true;
+      case 5: return listeners.fn.call(listeners.context, a1, a2, a3, a4), true;
+      case 6: return listeners.fn.call(listeners.context, a1, a2, a3, a4, a5), true;
+    }
+
+    for (i = 1, args = new Array(len -1); i < len; i++) {
+      args[i - 1] = arguments[i];
+    }
+
+    listeners.fn.apply(listeners.context, args);
+  } else {
+    var length = listeners.length
+      , j;
+
+    for (i = 0; i < length; i++) {
+      if (listeners[i].once) this.removeListener(event, listeners[i].fn, true);
+
+      switch (len) {
+        case 1: listeners[i].fn.call(listeners[i].context); break;
+        case 2: listeners[i].fn.call(listeners[i].context, a1); break;
+        case 3: listeners[i].fn.call(listeners[i].context, a1, a2); break;
+        default:
+          if (!args) for (j = 1, args = new Array(len -1); j < len; j++) {
+            args[j - 1] = arguments[j];
+          }
+
+          listeners[i].fn.apply(listeners[i].context, args);
+      }
+    }
+  }
+
+  return true;
+};
+
+/**
+ * Register a new EventListener for the given event.
+ *
+ * @param {String} event Name of the event.
+ * @param {Functon} fn Callback function.
+ * @param {Mixed} context The context of the function.
+ * @api public
+ */
+EventEmitter.prototype.on = function on(event, fn, context) {
+  var listener = new EE(fn, context || this);
+
+  if (!this._events) this._events = {};
+  if (!this._events[event]) this._events[event] = listener;
+  else {
+    if (!this._events[event].fn) this._events[event].push(listener);
+    else this._events[event] = [
+      this._events[event], listener
+    ];
+  }
+
+  return this;
+};
+
+/**
+ * Add an EventListener that's only called once.
+ *
+ * @param {String} event Name of the event.
+ * @param {Function} fn Callback function.
+ * @param {Mixed} context The context of the function.
+ * @api public
+ */
+EventEmitter.prototype.once = function once(event, fn, context) {
+  var listener = new EE(fn, context || this, true);
+
+  if (!this._events) this._events = {};
+  if (!this._events[event]) this._events[event] = listener;
+  else {
+    if (!this._events[event].fn) this._events[event].push(listener);
+    else this._events[event] = [
+      this._events[event], listener
+    ];
+  }
+
+  return this;
+};
+
+/**
+ * Remove event listeners.
+ *
+ * @param {String} event The event we want to remove.
+ * @param {Function} fn The listener that we need to find.
+ * @param {Boolean} once Only remove once listeners.
+ * @api public
+ */
+EventEmitter.prototype.removeListener = function removeListener(event, fn, once) {
+  if (!this._events || !this._events[event]) return this;
+
+  var listeners = this._events[event]
+    , events = [];
+
+  if (fn) {
+    if (listeners.fn && (listeners.fn !== fn || (once && !listeners.once))) {
+      events.push(listeners);
+    }
+    if (!listeners.fn) for (var i = 0, length = listeners.length; i < length; i++) {
+      if (listeners[i].fn !== fn || (once && !listeners[i].once)) {
+        events.push(listeners[i]);
+      }
+    }
+  }
+
+  //
+  // Reset the array, or remove it completely if we have no more listeners.
+  //
+  if (events.length) {
+    this._events[event] = events.length === 1 ? events[0] : events;
+  } else {
+    delete this._events[event];
+  }
+
+  return this;
+};
+
+/**
+ * Remove all listeners or only the listeners for the specified event.
+ *
+ * @param {String} event The event want to remove all listeners for.
+ * @api public
+ */
+EventEmitter.prototype.removeAllListeners = function removeAllListeners(event) {
+  if (!this._events) return this;
+
+  if (event) delete this._events[event];
+  else this._events = {};
+
+  return this;
+};
+
+//
+// Alias methods names because people roll like that.
+//
+EventEmitter.prototype.off = EventEmitter.prototype.removeListener;
+EventEmitter.prototype.addListener = EventEmitter.prototype.on;
+
+//
+// This function doesn't apply anymore.
+//
+EventEmitter.prototype.setMaxListeners = function setMaxListeners() {
+  return this;
+};
+
+//
+// Expose the module.
+//
+EventEmitter.EventEmitter = EventEmitter;
+EventEmitter.EventEmitter2 = EventEmitter;
+EventEmitter.EventEmitter3 = EventEmitter;
+
+//
+// Expose the module.
+//
+module.exports = EventEmitter;
+
+},{}],7:[function(require,module,exports){
+/**
+ * Copyright (c) 2014, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+module.exports.Dispatcher = require('./lib/Dispatcher')
+
+},{"./lib/Dispatcher":8}],8:[function(require,module,exports){
+/*
+ * Copyright (c) 2014, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule Dispatcher
+ * @typechecks
+ */
+
+"use strict";
+
+var invariant = require('./invariant');
+
+var _lastID = 1;
+var _prefix = 'ID_';
+
+/**
+ * Dispatcher is used to broadcast payloads to registered callbacks. This is
+ * different from generic pub-sub systems in two ways:
+ *
+ *   1) Callbacks are not subscribed to particular events. Every payload is
+ *      dispatched to every registered callback.
+ *   2) Callbacks can be deferred in whole or part until other callbacks have
+ *      been executed.
+ *
+ * For example, consider this hypothetical flight destination form, which
+ * selects a default city when a country is selected:
+ *
+ *   var flightDispatcher = new Dispatcher();
+ *
+ *   // Keeps track of which country is selected
+ *   var CountryStore = {country: null};
+ *
+ *   // Keeps track of which city is selected
+ *   var CityStore = {city: null};
+ *
+ *   // Keeps track of the base flight price of the selected city
+ *   var FlightPriceStore = {price: null}
+ *
+ * When a user changes the selected city, we dispatch the payload:
+ *
+ *   flightDispatcher.dispatch({
+ *     actionType: 'city-update',
+ *     selectedCity: 'paris'
+ *   });
+ *
+ * This payload is digested by `CityStore`:
+ *
+ *   flightDispatcher.register(function(payload) {
+ *     if (payload.actionType === 'city-update') {
+ *       CityStore.city = payload.selectedCity;
+ *     }
+ *   });
+ *
+ * When the user selects a country, we dispatch the payload:
+ *
+ *   flightDispatcher.dispatch({
+ *     actionType: 'country-update',
+ *     selectedCountry: 'australia'
+ *   });
+ *
+ * This payload is digested by both stores:
+ *
+ *    CountryStore.dispatchToken = flightDispatcher.register(function(payload) {
+ *     if (payload.actionType === 'country-update') {
+ *       CountryStore.country = payload.selectedCountry;
+ *     }
+ *   });
+ *
+ * When the callback to update `CountryStore` is registered, we save a reference
+ * to the returned token. Using this token with `waitFor()`, we can guarantee
+ * that `CountryStore` is updated before the callback that updates `CityStore`
+ * needs to query its data.
+ *
+ *   CityStore.dispatchToken = flightDispatcher.register(function(payload) {
+ *     if (payload.actionType === 'country-update') {
+ *       // `CountryStore.country` may not be updated.
+ *       flightDispatcher.waitFor([CountryStore.dispatchToken]);
+ *       // `CountryStore.country` is now guaranteed to be updated.
+ *
+ *       // Select the default city for the new country
+ *       CityStore.city = getDefaultCityForCountry(CountryStore.country);
+ *     }
+ *   });
+ *
+ * The usage of `waitFor()` can be chained, for example:
+ *
+ *   FlightPriceStore.dispatchToken =
+ *     flightDispatcher.register(function(payload) {
+ *       switch (payload.actionType) {
+ *         case 'country-update':
+ *           flightDispatcher.waitFor([CityStore.dispatchToken]);
+ *           FlightPriceStore.price =
+ *             getFlightPriceStore(CountryStore.country, CityStore.city);
+ *           break;
+ *
+ *         case 'city-update':
+ *           FlightPriceStore.price =
+ *             FlightPriceStore(CountryStore.country, CityStore.city);
+ *           break;
+ *     }
+ *   });
+ *
+ * The `country-update` payload will be guaranteed to invoke the stores'
+ * registered callbacks in order: `CountryStore`, `CityStore`, then
+ * `FlightPriceStore`.
+ */
+
+  function Dispatcher() {
+    this.$Dispatcher_callbacks = {};
+    this.$Dispatcher_isPending = {};
+    this.$Dispatcher_isHandled = {};
+    this.$Dispatcher_isDispatching = false;
+    this.$Dispatcher_pendingPayload = null;
+  }
+
+  /**
+   * Registers a callback to be invoked with every dispatched payload. Returns
+   * a token that can be used with `waitFor()`.
+   *
+   * @param {function} callback
+   * @return {string}
+   */
+  Dispatcher.prototype.register=function(callback) {
+    var id = _prefix + _lastID++;
+    this.$Dispatcher_callbacks[id] = callback;
+    return id;
+  };
+
+  /**
+   * Removes a callback based on its token.
+   *
+   * @param {string} id
+   */
+  Dispatcher.prototype.unregister=function(id) {
+    invariant(
+      this.$Dispatcher_callbacks[id],
+      'Dispatcher.unregister(...): `%s` does not map to a registered callback.',
+      id
+    );
+    delete this.$Dispatcher_callbacks[id];
+  };
+
+  /**
+   * Waits for the callbacks specified to be invoked before continuing execution
+   * of the current callback. This method should only be used by a callback in
+   * response to a dispatched payload.
+   *
+   * @param {array<string>} ids
+   */
+  Dispatcher.prototype.waitFor=function(ids) {
+    invariant(
+      this.$Dispatcher_isDispatching,
+      'Dispatcher.waitFor(...): Must be invoked while dispatching.'
+    );
+    for (var ii = 0; ii < ids.length; ii++) {
+      var id = ids[ii];
+      if (this.$Dispatcher_isPending[id]) {
+        invariant(
+          this.$Dispatcher_isHandled[id],
+          'Dispatcher.waitFor(...): Circular dependency detected while ' +
+          'waiting for `%s`.',
+          id
+        );
+        continue;
+      }
+      invariant(
+        this.$Dispatcher_callbacks[id],
+        'Dispatcher.waitFor(...): `%s` does not map to a registered callback.',
+        id
+      );
+      this.$Dispatcher_invokeCallback(id);
+    }
+  };
+
+  /**
+   * Dispatches a payload to all registered callbacks.
+   *
+   * @param {object} payload
+   */
+  Dispatcher.prototype.dispatch=function(payload) {
+    invariant(
+      !this.$Dispatcher_isDispatching,
+      'Dispatch.dispatch(...): Cannot dispatch in the middle of a dispatch.'
+    );
+    this.$Dispatcher_startDispatching(payload);
+    try {
+      for (var id in this.$Dispatcher_callbacks) {
+        if (this.$Dispatcher_isPending[id]) {
+          continue;
+        }
+        this.$Dispatcher_invokeCallback(id);
+      }
+    } finally {
+      this.$Dispatcher_stopDispatching();
+    }
+  };
+
+  /**
+   * Is this Dispatcher currently dispatching.
+   *
+   * @return {boolean}
+   */
+  Dispatcher.prototype.isDispatching=function() {
+    return this.$Dispatcher_isDispatching;
+  };
+
+  /**
+   * Call the callback stored with the given id. Also do some internal
+   * bookkeeping.
+   *
+   * @param {string} id
+   * @internal
+   */
+  Dispatcher.prototype.$Dispatcher_invokeCallback=function(id) {
+    this.$Dispatcher_isPending[id] = true;
+    this.$Dispatcher_callbacks[id](this.$Dispatcher_pendingPayload);
+    this.$Dispatcher_isHandled[id] = true;
+  };
+
+  /**
+   * Set up bookkeeping needed when dispatching.
+   *
+   * @param {object} payload
+   * @internal
+   */
+  Dispatcher.prototype.$Dispatcher_startDispatching=function(payload) {
+    for (var id in this.$Dispatcher_callbacks) {
+      this.$Dispatcher_isPending[id] = false;
+      this.$Dispatcher_isHandled[id] = false;
+    }
+    this.$Dispatcher_pendingPayload = payload;
+    this.$Dispatcher_isDispatching = true;
+  };
+
+  /**
+   * Clear bookkeeping used for dispatching.
+   *
+   * @internal
+   */
+  Dispatcher.prototype.$Dispatcher_stopDispatching=function() {
+    this.$Dispatcher_pendingPayload = null;
+    this.$Dispatcher_isDispatching = false;
+  };
+
+
+module.exports = Dispatcher;
+
+},{"./invariant":9}],9:[function(require,module,exports){
+/**
+ * Copyright (c) 2014, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule invariant
+ */
+
+"use strict";
+
+/**
+ * Use invariant() to assert state which your program assumes to be true.
+ *
+ * Provide sprintf-style format (only %s is supported) and arguments
+ * to provide information about what broke and what you were
+ * expecting.
+ *
+ * The invariant message will be stripped in production, but the invariant
+ * will remain to ensure logic does not differ in production.
+ */
+
+var invariant = function(condition, format, a, b, c, d, e, f) {
+  if (false) {
+    if (format === undefined) {
+      throw new Error('invariant requires an error message argument');
+    }
+  }
+
+  if (!condition) {
+    var error;
+    if (format === undefined) {
+      error = new Error(
+        'Minified exception occurred; use the non-minified dev environment ' +
+        'for the full error message and additional helpful warnings.'
+      );
+    } else {
+      var args = [a, b, c, d, e, f];
+      var argIndex = 0;
+      error = new Error(
+        'Invariant Violation: ' +
+        format.replace(/%s/g, function() { return args[argIndex++]; })
+      );
+    }
+
+    error.framesToPop = 1; // we don't care about invariant's own frame
+    throw error;
+  }
+};
+
+module.exports = invariant;
+
+},{}],10:[function(require,module,exports){
+'use strict';
+
+function ToObject(val) {
+	if (val == null) {
+		throw new TypeError('Object.assign cannot be called with null or undefined');
+	}
+
+	return Object(val);
+}
+
+module.exports = Object.assign || function (target, source) {
+	var from;
+	var keys;
+	var to = ToObject(target);
+
+	for (var s = 1; s < arguments.length; s++) {
+		from = arguments[s];
+		keys = Object.keys(Object(from));
+
+		for (var i = 0; i < keys.length; i++) {
+			to[keys[i]] = from[keys[i]];
+		}
+	}
+
+	return to;
+};
+
+},{}],11:[function(require,module,exports){
+"use strict";
+
+var _interopRequire = function (obj) { return obj && obj.__esModule ? obj["default"] : obj; };
+
+var Alt = _interopRequire(require("./alt"));
+
+var ReactStateMagicMixin = _interopRequire(require("../mixins/ReactStateMagicMixin"));
+
+var ListenerMixin = _interopRequire(require("../mixins/ListenerMixin"));
+
+var FluxyMixin = _interopRequire(require("../mixins/FluxyMixin"));
+
+var Subscribe = _interopRequire(require("../mixins/Subscribe"));
+
+var ActionListeners = _interopRequire(require("../utils/ActionListeners"));
+
+var DispatcherRecorder = _interopRequire(require("../utils/DispatcherRecorder"));
+
+var makeFinalStore = _interopRequire(require("../utils/makeFinalStore"));
+
+Alt.addons = {
+  ReactStateMagicMixin: ReactStateMagicMixin,
+  ListenerMixin: ListenerMixin,
+  FluxyMixin: FluxyMixin,
+  Subscribe: Subscribe,
+  ActionListeners: ActionListeners,
+  DispatcherRecorder: DispatcherRecorder,
+  makeFinalStore: makeFinalStore
+};
+
+Alt.mixins = {
+  ReactStateMagicMixin: ReactStateMagicMixin,
+  ListenerMixin: ListenerMixin,
+  FluxyMixin: FluxyMixin
+};
+
+Alt.utils = {
+  Subscribe: Subscribe,
+  ActionListeners: ActionListeners,
+  DispatcherRecorder: DispatcherRecorder,
+  makeFinalStore: makeFinalStore
+};
+
+module.exports = Alt;
+
+},{"../mixins/FluxyMixin":1,"../mixins/ListenerMixin":2,"../mixins/ReactStateMagicMixin":3,"../mixins/Subscribe":4,"../utils/ActionListeners":13,"../utils/DispatcherRecorder":14,"../utils/makeFinalStore":15,"./alt":12}],12:[function(require,module,exports){
+"use strict";
+
+var _interopRequire = function (obj) { return obj && obj.__esModule ? obj["default"] : obj; };
+
+var _get = function get(object, property, receiver) { var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc && desc.writable) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };
+
+var _inherits = function (subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; };
+
+var _createClass = (function () { function defineProperties(target, props) { for (var key in props) { var prop = props[key]; prop.configurable = true; if (prop.value) prop.writable = true; } Object.defineProperties(target, props); } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
+var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } };
+
+var Dispatcher = require("flux").Dispatcher;
+
+var EventEmitter = _interopRequire(require("eventemitter3"));
+
+var Symbol = _interopRequire(require("es-symbol"));
+
+var assign = _interopRequire(require("object-assign"));
+
+var now = Date.now();
+var VariableSymbol = function (desc) {
+  return Symbol("" + now + "" + desc);
+};
+
+var ACTION_HANDLER = Symbol("action creator handler");
+var ACTION_KEY = Symbol("holds the actions uid symbol for listening");
+var ACTION_UID = Symbol("the actions uid name");
+var EE = Symbol("event emitter instance");
+var INIT_SNAPSHOT = Symbol("init snapshot storage");
+var LAST_SNAPSHOT = Symbol("last snapshot storage");
+var LIFECYCLE = Symbol("store lifecycle listeners");
+var LISTENERS = Symbol("stores action listeners storage");
+var STATE_CONTAINER = VariableSymbol("the state container");
+
+var formatAsConstant = function (name) {
+  return name.replace(/[a-z]([A-Z])/g, function (i) {
+    return "" + i[0] + "_" + i[1].toLowerCase();
+  }).toUpperCase();
+};
+
+/* istanbul ignore next */
+function NoopClass() {}
+
+var builtIns = Object.getOwnPropertyNames(NoopClass);
+var builtInProto = Object.getOwnPropertyNames(NoopClass.prototype);
+
+var getInternalMethods = function (obj, excluded) {
+  return Object.getOwnPropertyNames(obj).reduce(function (value, m) {
+    if (excluded.indexOf(m) !== -1) {
+      return value;
+    }
+
+    value[m] = obj[m];
+    return value;
+  }, {});
+};
+
+var AltStore = (function () {
+  function AltStore(dispatcher, state) {
+    var _this6 = this;
+
+    _classCallCheck(this, AltStore);
+
+    this[EE] = new EventEmitter();
+    this[LIFECYCLE] = {};
+    this[STATE_CONTAINER] = state;
+
+    assign(this[LIFECYCLE], state[LIFECYCLE]);
+
+    // Register dispatcher
+    this.dispatchToken = dispatcher.register(function (payload) {
+      if (state[LISTENERS][payload.action]) {
+        var result = state[LISTENERS][payload.action](payload.data);
+        result !== false && _this6.emitChange();
+      }
+    });
+
+    if (this[LIFECYCLE].init) {
+      this[LIFECYCLE].init();
+    }
+  }
+
+  _createClass(AltStore, {
+    getEventEmitter: {
+      value: function getEventEmitter() {
+        return this[EE];
+      }
+    },
+    emitChange: {
+      value: function emitChange() {
+        this[EE].emit("change", this[STATE_CONTAINER]);
+      }
+    },
+    listen: {
+      value: function listen(cb) {
+        this[EE].on("change", cb);
+      }
+    },
+    unlisten: {
+      value: function unlisten(cb) {
+        this[EE].removeListener("change", cb);
+      }
+    },
+    getState: {
+      value: function getState() {
+        // Copy over state so it's RO.
+        return assign({}, this[STATE_CONTAINER]);
+      }
+    }
+  });
+
+  return AltStore;
+})();
+
+var ActionCreator = (function () {
+  function ActionCreator(alt, name, action, actions) {
+    _classCallCheck(this, ActionCreator);
+
+    this[ACTION_UID] = name;
+    this[ACTION_HANDLER] = action.bind(this);
+    this.actions = actions;
+    this.alt = alt;
+  }
+
+  _createClass(ActionCreator, {
+    dispatch: {
+      value: function dispatch(data) {
+        this.alt.dispatch(this[ACTION_UID], data);
+      }
+    }
+  });
+
+  return ActionCreator;
+})();
+
+var StoreMixin = {
+  on: function on(lifecycleEvent, handler) {
+    this[LIFECYCLE][lifecycleEvent] = handler.bind(this);
+  },
+
+  bindAction: function bindAction(symbol, handler) {
+    if (!symbol) {
+      throw new ReferenceError("Invalid action reference passed in");
+    }
+    if (typeof handler !== "function") {
+      throw new TypeError("bindAction expects a function");
+    }
+
+    if (handler.length > 1) {
+      throw new TypeError("Action handler in store " + this._storeName + " for " + ("" + (symbol[ACTION_KEY] || symbol).toString() + " was defined with 2 ") + "parameters. Only a single parameter is passed through the " + "dispatcher, did you mean to pass in an Object instead?");
+    }
+
+    // You can pass in the constant or the function itself
+    if (symbol[ACTION_KEY]) {
+      this[LISTENERS][symbol[ACTION_KEY]] = handler.bind(this);
+    } else {
+      this[LISTENERS][symbol] = handler.bind(this);
+    }
+  },
+
+  bindActions: function bindActions(actions) {
+    var _this6 = this;
+
+    Object.keys(actions).forEach(function (action) {
+      var symbol = actions[action];
+      var matchFirstCharacter = /./;
+      var assumedEventHandler = action.replace(matchFirstCharacter, function (x) {
+        return "on" + x[0].toUpperCase();
+      });
+      var handler = null;
+
+      if (_this6[action] && _this6[assumedEventHandler]) {
+        // If you have both action and onAction
+        throw new ReferenceError("You have multiple action handlers bound to an action: " + ("" + action + " and " + assumedEventHandler));
+      } else if (_this6[action]) {
+        // action
+        handler = _this6[action];
+      } else if (_this6[assumedEventHandler]) {
+        // onAction
+        handler = _this6[assumedEventHandler];
+      }
+
+      if (handler) {
+        _this6.bindAction(symbol, handler);
+      }
+    });
+  },
+
+  bindListeners: function bindListeners(obj) {
+    var _this6 = this;
+
+    Object.keys(obj).forEach(function (methodName) {
+      var symbol = obj[methodName];
+      var listener = _this6[methodName];
+
+      if (!listener) {
+        throw new ReferenceError("" + methodName + " defined but does not exist in " + _this6._storeName);
+      }
+
+      if (Array.isArray(symbol)) {
+        symbol.forEach(function (action) {
+          return _this6.bindAction(action, listener);
+        });
+      } else {
+        _this6.bindAction(symbol, listener);
+      }
+    });
+  },
+
+  waitFor: function waitFor(sources) {
+    if (!sources) {
+      throw new ReferenceError("Dispatch tokens not provided");
+    }
+
+    if (arguments.length === 1) {
+      sources = Array.isArray(sources) ? sources : [sources];
+    } else {
+      sources = Array.prototype.slice.call(arguments);
+    }
+
+    var tokens = sources.map(function (source) {
+      return source.dispatchToken || source;
+    });
+
+    this.dispatcher.waitFor(tokens);
+  }
+};
+
+var setAppState = function (instance, data, onStore) {
+  var obj = JSON.parse(data);
+  Object.keys(obj).forEach(function (key) {
+    assign(instance.stores[key][STATE_CONTAINER], obj[key]);
+    onStore(instance.stores[key]);
+  });
+};
+
+var snapshot = function (instance) {
+  return JSON.stringify(Object.keys(instance.stores).reduce(function (obj, key) {
+    if (instance.stores[key][LIFECYCLE].snapshot) {
+      instance.stores[key][LIFECYCLE].snapshot();
+    }
+    obj[key] = instance.stores[key].getState();
+    return obj;
+  }, {}));
+};
+
+var saveInitialSnapshot = function (instance, key) {
+  var state = instance.stores[key][STATE_CONTAINER];
+  var initial = JSON.parse(instance[INIT_SNAPSHOT]);
+  initial[key] = state;
+  instance[INIT_SNAPSHOT] = JSON.stringify(initial);
+};
+
+var filterSnapshotOfStores = function (snapshot, storeNames) {
+  var stores = JSON.parse(snapshot);
+  var storesToReset = storeNames.reduce(function (obj, name) {
+    if (!stores[name]) {
+      throw new ReferenceError("" + name + " is not a valid store");
+    }
+    obj[name] = stores[name];
+    return obj;
+  }, {});
+  return JSON.stringify(storesToReset);
+};
+
+var Alt = (function () {
+  function Alt() {
+    _classCallCheck(this, Alt);
+
+    this.dispatcher = new Dispatcher();
+    this.actions = {};
+    this.stores = {};
+    this[LAST_SNAPSHOT] = null;
+    this[INIT_SNAPSHOT] = "{}";
+  }
+
+  _createClass(Alt, {
+    dispatch: {
+      value: function dispatch(action, data) {
+        this.dispatcher.dispatch({ action: action, data: data });
+      }
+    },
+    createStore: {
+      value: function createStore(StoreModel, iden) {
+        var saveStore = arguments[2] === undefined ? true : arguments[2];
+
+        var storeInstance = undefined;
+        var key = iden || StoreModel.name || StoreModel.displayName || "";
+
+        if (saveStore && (this.stores[key] || !key)) {
+          /* istanbul ignore else */
+          if (typeof console !== "undefined") {
+            if (this.stores[key]) {
+              console.warn(new ReferenceError("A store named " + key + " already exists, double check your store " + "names or pass in your own custom identifier for each store"));
+            } else {
+              console.warn(new ReferenceError("Store name was not specified"));
+            }
+          }
+
+          // guarantee the store has a unique key name
+          var count = 0;
+          while (this.stores[key]) {
+            key = key + String(++count);
+          }
+        }
+
+        // Creating a class here so we don't overload the provided store's
+        // prototype with the mixin behaviour and I'm extending from StoreModel
+        // so we can inherit any extensions from the provided store.
+
+        var Store = (function (_StoreModel) {
+          function Store(alt) {
+            _classCallCheck(this, Store);
+
+            this[LIFECYCLE] = {};
+            this[LISTENERS] = {};
+            _get(Object.getPrototypeOf(Store.prototype), "constructor", this).call(this, alt);
+          }
+
+          _inherits(Store, _StoreModel);
+
+          return Store;
+        })(StoreModel);
+
+        assign(Store.prototype, StoreMixin, {
+          _storeName: key,
+          alt: this,
+          dispatcher: this.dispatcher,
+          getInstance: function getInstance() {
+            return storeInstance;
+          },
+          emitChange: function emitChange() {
+            this.getInstance().emitChange();
+          },
+          setState: function setState() {
+            var values = arguments[0] === undefined ? {} : arguments[0];
+
+            assign(this, values);
+            this.emitChange();
+            return false;
+          }
+        });
+
+        var store = new Store(this);
+
+        storeInstance = assign(new AltStore(this.dispatcher, store), getInternalMethods(StoreModel, builtIns));
+
+        if (saveStore) {
+          this.stores[key] = storeInstance;
+          saveInitialSnapshot(this, key);
+        }
+
+        return storeInstance;
+      }
+    },
+    generateActions: {
+      value: function generateActions() {
+        for (var _len = arguments.length, actionNames = Array(_len), _key = 0; _key < _len; _key++) {
+          actionNames[_key] = arguments[_key];
+        }
+
+        return this.createActions(function () {
+          var _ref;
+
+          (_ref = this).generateActions.apply(_ref, actionNames);
+        });
+      }
+    },
+    createActions: {
+      value: function createActions(ActionsClass) {
+        var _this6 = this;
+
+        var exportObj = arguments[1] === undefined ? {} : arguments[1];
+
+        var actions = assign({}, getInternalMethods(ActionsClass.prototype, builtInProto));
+        var key = ActionsClass.name || ActionsClass.displayName || "";
+
+        var ActionsGenerator = (function (_ActionsClass) {
+          function ActionsGenerator(alt) {
+            _classCallCheck(this, ActionsGenerator);
+
+            _get(Object.getPrototypeOf(ActionsGenerator.prototype), "constructor", this).call(this, alt);
+          }
+
+          _inherits(ActionsGenerator, _ActionsClass);
+
+          _createClass(ActionsGenerator, {
+            generateActions: {
+              value: function generateActions() {
+                for (var _len = arguments.length, actionNames = Array(_len), _key = 0; _key < _len; _key++) {
+                  actionNames[_key] = arguments[_key];
+                }
+
+                actionNames.forEach(function (actionName) {
+                  // This is a function so we can later bind this to ActionCreator
+                  actions[actionName] = function (x) {
+                    for (var _len2 = arguments.length, a = Array(_len2 > 1 ? _len2 - 1 : 0), _key2 = 1; _key2 < _len2; _key2++) {
+                      a[_key2 - 1] = arguments[_key2];
+                    }
+
+                    this.dispatch(a.length ? [x].concat(a) : x);
+                  };
+                });
+              }
+            }
+          });
+
+          return ActionsGenerator;
+        })(ActionsClass);
+
+        new ActionsGenerator(this);
+
+        return Object.keys(actions).reduce(function (obj, action) {
+          var constant = formatAsConstant(action);
+          var actionName = Symbol("" + key + "#" + action);
+
+          // Wrap the action so we can provide a dispatch method
+          var newAction = new ActionCreator(_this6, actionName, actions[action], obj);
+
+          // Set all the properties on action
+          obj[action] = newAction[ACTION_HANDLER];
+          obj[action].defer = function () {
+            for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+              args[_key] = arguments[_key];
+            }
+
+            setTimeout(function () {
+              return newAction[ACTION_HANDLER].apply(null, args);
+            });
+          };
+          obj[action][ACTION_KEY] = actionName;
+          obj[constant] = actionName;
+
+          return obj;
+        }, exportObj);
+      }
+    },
+    takeSnapshot: {
+      value: function takeSnapshot() {
+        var state = snapshot(this);
+        this[LAST_SNAPSHOT] = state;
+        return state;
+      }
+    },
+    rollback: {
+      value: function rollback() {
+        setAppState(this, this[LAST_SNAPSHOT], function (store) {
+          if (store[LIFECYCLE].rollback) {
+            store[LIFECYCLE].rollback();
+          }
+        });
+      }
+    },
+    recycle: {
+      value: function recycle() {
+        for (var _len = arguments.length, storeNames = Array(_len), _key = 0; _key < _len; _key++) {
+          storeNames[_key] = arguments[_key];
+        }
+
+        var snapshot = storeNames.length ? filterSnapshotOfStores(this[INIT_SNAPSHOT], storeNames) : this[INIT_SNAPSHOT];
+
+        setAppState(this, snapshot, function (store) {
+          if (store[LIFECYCLE].init) {
+            store[LIFECYCLE].init();
+          }
+        });
+      }
+    },
+    flush: {
+      value: function flush() {
+        var state = snapshot(this);
+        this.recycle();
+        return state;
+      }
+    },
+    bootstrap: {
+      value: function bootstrap(data) {
+        setAppState(this, data, function (store) {
+          if (store[LIFECYCLE].bootstrap) {
+            store[LIFECYCLE].bootstrap();
+          }
+        });
+      }
+    },
+    addActions: {
+
+      // Instance type methods for injecting alt into your application as context
+
+      value: function addActions(name, ActionsClass) {
+        this.actions[name] = this.createActions(ActionsClass);
+      }
+    },
+    addStore: {
+      value: function addStore(name, StoreModel, saveStore) {
+        this.createStore(StoreModel, name, saveStore);
+      }
+    },
+    getActions: {
+      value: function getActions(name) {
+        return this.actions[name];
+      }
+    },
+    getStore: {
+      value: function getStore(name) {
+        return this.stores[name];
+      }
+    }
+  });
+
+  return Alt;
+})();
+
+module.exports = Alt;
+
+},{"es-symbol":5,"eventemitter3":6,"flux":7,"object-assign":10}],13:[function(require,module,exports){
+"use strict";
+
+/**
+ * ActionListeners(alt: AltInstance): ActionListenersInstance
+ *
+ * > Globally listen to individual actions
+ *
+ * If you need to listen to an action but don't want the weight of a store
+ * then this util is what you can use.
+ *
+ * Usage:
+ *
+ * ```js
+ * var actionListener = new ActionListeners(alt);
+ *
+ * actionListener.addActionListener(Action.ACTION_NAME, function (data) {
+ *   // do something with data
+ * })
+ * ```
+ */
+module.exports = ActionListeners;
+
+var Symbol = require("es-symbol");
+var ALT_LISTENERS = Symbol("global dispatcher listeners");
+
+function ActionListeners(alt) {
+  this.dispatcher = alt.dispatcher;
+  this[ALT_LISTENERS] = {};
+}
+
+/*
+ * addActionListener(symAction: symbol, handler: function): number
+ * Adds a listener to a specified action and returns the dispatch token.
+ */
+ActionListeners.prototype.addActionListener = function (symAction, handler) {
+  var id = this.dispatcher.register(function (payload) {
+    symAction === payload.action && handler(payload.data);
+  });
+  this[ALT_LISTENERS][id] = true;
+  return id;
+};
+
+/*
+ * removeActionListener(id: number): undefined
+ * Removes the specified dispatch registration.
+ */
+ActionListeners.prototype.removeActionListener = function (id) {
+  delete this[ALT_LISTENERS][id];
+  this.dispatcher.unregister(id);
+};
+
+/**
+ * Remove all listeners.
+ */
+ActionListeners.prototype.removeAllActionListeners = function () {
+  Object.keys(this[ALT_LISTENERS]).forEach(this.removeActionListener.bind(this));
+  this[ALT_LISTENERS] = {};
+};
+
+},{"es-symbol":5}],14:[function(require,module,exports){
+"use strict";
+
+/**
+ * DispatcherRecorder(alt: AltInstance): DispatcherInstance
+ *
+ * > Record and replay your actions at any point in time.
+ *
+ * This util allows you to record a set of dispatches which you can later
+ * replay at your convenience.
+ *
+ * Good for: Debugging, repeating, logging.
+ *
+ * Usage:
+ *
+ * ```js
+ * var recorder = new DispatcherRecorder(alt);
+ *
+ * // start recording
+ * recorder.record();
+ *
+ * // call a series of actions
+ *
+ * // stop recording
+ * recorder.stop();
+ *
+ * // replay the events that took place
+ * recorder.replay();
+ * ```
+ */
+module.exports = DispatcherRecorder;
+
+function DispatcherRecorder(alt) {
+  this.alt = alt;
+  this.events = [];
+  this.dispatchToken = null;
+}
+
+/**
+ * record(): boolean
+ * If recording started you get true, otherwise false since there's a recording
+ * in progress.
+ */
+DispatcherRecorder.prototype.record = function () {
+  if (this.dispatchToken) {
+    return false;
+  }
+
+  this.dispatchToken = this.alt.dispatcher.register((function (payload) {
+    this.events.push(payload);
+  }).bind(this));
+
+  return true;
+};
+
+/**
+ * Stops the recording in progress.
+ */
+DispatcherRecorder.prototype.stop = function () {
+  this.alt.dispatcher.unregister(this.dispatchToken);
+  this.dispatchToken = null;
+};
+
+/**
+ * Clear all events from memory.
+ */
+DispatcherRecorder.prototype.clear = function () {
+  this.events = [];
+};
+
+/**
+ * Synchronously replay all events that were recorded.
+ */
+DispatcherRecorder.prototype.replay = function () {
+  this.events.forEach((function (payload) {
+    this.alt.dispatch(payload.action, payload.data);
+  }).bind(this));
+};
+
+},{}],15:[function(require,module,exports){
+"use strict";
+
+/**
+ * makeFinalStore(alt: AltInstance): AltStore
+ *
+ * > Creates a `FinalStore` which is a store like any other except that it
+ * waits for all other stores in your alt instance to emit a change before it
+ * emits a change itself.
+ *
+ * Want to know when a particular dispatch has completed? This is the util
+ * you want.
+ *
+ * Good for: taking a snapshot and persisting it somewhere, saving data from
+ * a set of stores, syncing data, etc.
+ *
+ * Usage:
+ *
+ * ```js
+ * var FinalStore = makeFinalStore(alt);
+ *
+ * FinalStore.listen(function () {
+ *   // all stores have now changed
+ * });
+ * ```
+ */
+module.exports = makeFinalStore;
+
+function FinalStore() {
+  this.dispatcher.register((function (payload) {
+    var stores = Object.keys(this.alt.stores).reduce((function (arr, store) {
+      return (arr.push(this.alt.stores[store].dispatchToken), arr);
+    }).bind(this), []);
+
+    this.waitFor(stores);
+    this.getInstance().emitChange();
+  }).bind(this));
+}
+
+function makeFinalStore(alt) {
+  return alt.createStore(FinalStore, "AltFinalStore", false);
+}
+
+},{}]},{},[11])(11)
+});

--- a/dist/alt-browser.js
+++ b/dist/alt-browser.js
@@ -1,0 +1,1242 @@
+(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.Alt = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+"use strict";
+
+var _defineProperty = function (obj, key, value) { return Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); };
+
+var globalSymbolRegistryList = {};
+
+// Aliases & Helpers
+var make = Object.create;
+var defProps = Object.defineProperties;
+var defProp = Object.defineProperty;
+var defValue = function (value) {
+  var opts = arguments[1] === undefined ? {} : arguments[1];
+  return {
+    value: value,
+    configurable: !!opts.c,
+    writable: !!opts.w,
+    enumerable: !!opts.e
+  };
+};
+var isSymbol = function (symbol) {
+  return symbol && symbol[xSymbol.toStringTag] === "Symbol";
+};
+
+var id = {};
+var uid = function (desc) {
+  desc = String(desc);
+  var x = "";
+  var i = 0;
+  while (id[desc + x]) {
+    x = i += 1;
+  }
+  id[desc + x] = 1;
+
+  var tag = "Symbol(" + desc + "" + x + ")";
+
+  // Make the symbols hidden to pre-es6 code
+  defProp(Object.prototype, tag, {
+    get: undefined,
+    set: function (value) {
+      defProp(this, tag, defValue(value, { c: true, w: true }));
+    },
+    configurable: true,
+    enumerable: false
+  });
+
+  return tag;
+};
+
+// The base symbol
+var SymbolProto = make(null);
+
+// 19.4.1.1
+function xSymbol(descString) {
+  if (this instanceof xSymbol) {
+    throw new TypeError("Symbol is not a constructor");
+  }
+
+  descString = descString === undefined ? "" : String(descString);
+
+  var tag = uid(descString);
+
+  return make(SymbolProto, {
+    __description__: defValue(descString),
+    __tag__: defValue(tag)
+  });
+}
+
+defProps(xSymbol, {
+  // 19.4.2.1
+  "for": defValue(function (key) {
+    var stringKey = String(key);
+
+    if (globalSymbolRegistryList[stringKey]) {
+      return globalSymbolRegistryList[stringKey];
+    }
+
+    var symbol = xSymbol(stringKey);
+    globalSymbolRegistryList[stringKey] = symbol;
+
+    return symbol;
+  }),
+
+  // 19.4.2.5
+  keyFor: defValue(function (sym) {
+    if (!isSymbol(sym)) {
+      throw new TypeError("" + sym + " is not a symbol");
+    }
+
+    for (var key in globalSymbolRegistryList) {
+      if (globalSymbolRegistryList[key] === sym) {
+        return globalSymbolRegistryList[key].__description__;
+      }
+    }
+  })
+});
+
+// 6.1.5.1
+defProps(xSymbol, {
+  hasInstance: defValue(xSymbol("hasInstance")),
+  isConcatSpreadable: defValue(xSymbol("isConcatSpreadable")),
+  iterator: defValue(xSymbol("iterator")),
+  match: defValue(xSymbol("match")),
+  replace: defValue(xSymbol("replace")),
+  search: defValue(xSymbol("search")),
+  species: defValue(xSymbol("species")),
+  split: defValue(xSymbol("split")),
+  toPrimitive: defValue(xSymbol("toPrimitive")),
+  toStringTag: defValue(xSymbol("toStringTag")),
+  unscopables: defValue(xSymbol("unscopables"))
+});
+
+// 19.4.3
+defProps(SymbolProto, {
+  constructor: defValue(xSymbol),
+
+  // 19.4.3.2
+  toString: defValue(function () {
+    return this.__tag__;
+  }),
+
+  // 19.4.3.3
+  valueOf: defValue(function () {
+    return "Symbol(" + this.__description__ + ")";
+  })
+});
+
+defProps(SymbolProto, (function () {
+  var _defProps = {};
+
+  _defineProperty(_defProps, xSymbol.toPrimitive, defValue(function (hint) {
+    return this;
+  }, { c: true }));
+
+  _defineProperty(_defProps, xSymbol.toStringTag, defValue("Symbol", { c: true }));
+
+  return _defProps;
+})());
+
+module.exports = typeof Symbol === "function" ? Symbol : xSymbol;
+// 19.4.3.4 XXX Does not follow spec.
+
+
+// 19.4.3.5
+
+
+},{}],2:[function(require,module,exports){
+'use strict';
+
+/**
+ * Representation of a single EventEmitter function.
+ *
+ * @param {Function} fn Event handler to be called.
+ * @param {Mixed} context Context for function execution.
+ * @param {Boolean} once Only emit once
+ * @api private
+ */
+function EE(fn, context, once) {
+  this.fn = fn;
+  this.context = context;
+  this.once = once || false;
+}
+
+/**
+ * Minimal EventEmitter interface that is molded against the Node.js
+ * EventEmitter interface.
+ *
+ * @constructor
+ * @api public
+ */
+function EventEmitter() { /* Nothing to set */ }
+
+/**
+ * Holds the assigned EventEmitters by name.
+ *
+ * @type {Object}
+ * @private
+ */
+EventEmitter.prototype._events = undefined;
+
+/**
+ * Return a list of assigned event listeners.
+ *
+ * @param {String} event The events that should be listed.
+ * @returns {Array}
+ * @api public
+ */
+EventEmitter.prototype.listeners = function listeners(event) {
+  if (!this._events || !this._events[event]) return [];
+  if (this._events[event].fn) return [this._events[event].fn];
+
+  for (var i = 0, l = this._events[event].length, ee = new Array(l); i < l; i++) {
+    ee[i] = this._events[event][i].fn;
+  }
+
+  return ee;
+};
+
+/**
+ * Emit an event to all registered event listeners.
+ *
+ * @param {String} event The name of the event.
+ * @returns {Boolean} Indication if we've emitted an event.
+ * @api public
+ */
+EventEmitter.prototype.emit = function emit(event, a1, a2, a3, a4, a5) {
+  if (!this._events || !this._events[event]) return false;
+
+  var listeners = this._events[event]
+    , len = arguments.length
+    , args
+    , i;
+
+  if ('function' === typeof listeners.fn) {
+    if (listeners.once) this.removeListener(event, listeners.fn, true);
+
+    switch (len) {
+      case 1: return listeners.fn.call(listeners.context), true;
+      case 2: return listeners.fn.call(listeners.context, a1), true;
+      case 3: return listeners.fn.call(listeners.context, a1, a2), true;
+      case 4: return listeners.fn.call(listeners.context, a1, a2, a3), true;
+      case 5: return listeners.fn.call(listeners.context, a1, a2, a3, a4), true;
+      case 6: return listeners.fn.call(listeners.context, a1, a2, a3, a4, a5), true;
+    }
+
+    for (i = 1, args = new Array(len -1); i < len; i++) {
+      args[i - 1] = arguments[i];
+    }
+
+    listeners.fn.apply(listeners.context, args);
+  } else {
+    var length = listeners.length
+      , j;
+
+    for (i = 0; i < length; i++) {
+      if (listeners[i].once) this.removeListener(event, listeners[i].fn, true);
+
+      switch (len) {
+        case 1: listeners[i].fn.call(listeners[i].context); break;
+        case 2: listeners[i].fn.call(listeners[i].context, a1); break;
+        case 3: listeners[i].fn.call(listeners[i].context, a1, a2); break;
+        default:
+          if (!args) for (j = 1, args = new Array(len -1); j < len; j++) {
+            args[j - 1] = arguments[j];
+          }
+
+          listeners[i].fn.apply(listeners[i].context, args);
+      }
+    }
+  }
+
+  return true;
+};
+
+/**
+ * Register a new EventListener for the given event.
+ *
+ * @param {String} event Name of the event.
+ * @param {Functon} fn Callback function.
+ * @param {Mixed} context The context of the function.
+ * @api public
+ */
+EventEmitter.prototype.on = function on(event, fn, context) {
+  var listener = new EE(fn, context || this);
+
+  if (!this._events) this._events = {};
+  if (!this._events[event]) this._events[event] = listener;
+  else {
+    if (!this._events[event].fn) this._events[event].push(listener);
+    else this._events[event] = [
+      this._events[event], listener
+    ];
+  }
+
+  return this;
+};
+
+/**
+ * Add an EventListener that's only called once.
+ *
+ * @param {String} event Name of the event.
+ * @param {Function} fn Callback function.
+ * @param {Mixed} context The context of the function.
+ * @api public
+ */
+EventEmitter.prototype.once = function once(event, fn, context) {
+  var listener = new EE(fn, context || this, true);
+
+  if (!this._events) this._events = {};
+  if (!this._events[event]) this._events[event] = listener;
+  else {
+    if (!this._events[event].fn) this._events[event].push(listener);
+    else this._events[event] = [
+      this._events[event], listener
+    ];
+  }
+
+  return this;
+};
+
+/**
+ * Remove event listeners.
+ *
+ * @param {String} event The event we want to remove.
+ * @param {Function} fn The listener that we need to find.
+ * @param {Boolean} once Only remove once listeners.
+ * @api public
+ */
+EventEmitter.prototype.removeListener = function removeListener(event, fn, once) {
+  if (!this._events || !this._events[event]) return this;
+
+  var listeners = this._events[event]
+    , events = [];
+
+  if (fn) {
+    if (listeners.fn && (listeners.fn !== fn || (once && !listeners.once))) {
+      events.push(listeners);
+    }
+    if (!listeners.fn) for (var i = 0, length = listeners.length; i < length; i++) {
+      if (listeners[i].fn !== fn || (once && !listeners[i].once)) {
+        events.push(listeners[i]);
+      }
+    }
+  }
+
+  //
+  // Reset the array, or remove it completely if we have no more listeners.
+  //
+  if (events.length) {
+    this._events[event] = events.length === 1 ? events[0] : events;
+  } else {
+    delete this._events[event];
+  }
+
+  return this;
+};
+
+/**
+ * Remove all listeners or only the listeners for the specified event.
+ *
+ * @param {String} event The event want to remove all listeners for.
+ * @api public
+ */
+EventEmitter.prototype.removeAllListeners = function removeAllListeners(event) {
+  if (!this._events) return this;
+
+  if (event) delete this._events[event];
+  else this._events = {};
+
+  return this;
+};
+
+//
+// Alias methods names because people roll like that.
+//
+EventEmitter.prototype.off = EventEmitter.prototype.removeListener;
+EventEmitter.prototype.addListener = EventEmitter.prototype.on;
+
+//
+// This function doesn't apply anymore.
+//
+EventEmitter.prototype.setMaxListeners = function setMaxListeners() {
+  return this;
+};
+
+//
+// Expose the module.
+//
+EventEmitter.EventEmitter = EventEmitter;
+EventEmitter.EventEmitter2 = EventEmitter;
+EventEmitter.EventEmitter3 = EventEmitter;
+
+//
+// Expose the module.
+//
+module.exports = EventEmitter;
+
+},{}],3:[function(require,module,exports){
+/**
+ * Copyright (c) 2014, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+module.exports.Dispatcher = require('./lib/Dispatcher')
+
+},{"./lib/Dispatcher":4}],4:[function(require,module,exports){
+/*
+ * Copyright (c) 2014, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule Dispatcher
+ * @typechecks
+ */
+
+"use strict";
+
+var invariant = require('./invariant');
+
+var _lastID = 1;
+var _prefix = 'ID_';
+
+/**
+ * Dispatcher is used to broadcast payloads to registered callbacks. This is
+ * different from generic pub-sub systems in two ways:
+ *
+ *   1) Callbacks are not subscribed to particular events. Every payload is
+ *      dispatched to every registered callback.
+ *   2) Callbacks can be deferred in whole or part until other callbacks have
+ *      been executed.
+ *
+ * For example, consider this hypothetical flight destination form, which
+ * selects a default city when a country is selected:
+ *
+ *   var flightDispatcher = new Dispatcher();
+ *
+ *   // Keeps track of which country is selected
+ *   var CountryStore = {country: null};
+ *
+ *   // Keeps track of which city is selected
+ *   var CityStore = {city: null};
+ *
+ *   // Keeps track of the base flight price of the selected city
+ *   var FlightPriceStore = {price: null}
+ *
+ * When a user changes the selected city, we dispatch the payload:
+ *
+ *   flightDispatcher.dispatch({
+ *     actionType: 'city-update',
+ *     selectedCity: 'paris'
+ *   });
+ *
+ * This payload is digested by `CityStore`:
+ *
+ *   flightDispatcher.register(function(payload) {
+ *     if (payload.actionType === 'city-update') {
+ *       CityStore.city = payload.selectedCity;
+ *     }
+ *   });
+ *
+ * When the user selects a country, we dispatch the payload:
+ *
+ *   flightDispatcher.dispatch({
+ *     actionType: 'country-update',
+ *     selectedCountry: 'australia'
+ *   });
+ *
+ * This payload is digested by both stores:
+ *
+ *    CountryStore.dispatchToken = flightDispatcher.register(function(payload) {
+ *     if (payload.actionType === 'country-update') {
+ *       CountryStore.country = payload.selectedCountry;
+ *     }
+ *   });
+ *
+ * When the callback to update `CountryStore` is registered, we save a reference
+ * to the returned token. Using this token with `waitFor()`, we can guarantee
+ * that `CountryStore` is updated before the callback that updates `CityStore`
+ * needs to query its data.
+ *
+ *   CityStore.dispatchToken = flightDispatcher.register(function(payload) {
+ *     if (payload.actionType === 'country-update') {
+ *       // `CountryStore.country` may not be updated.
+ *       flightDispatcher.waitFor([CountryStore.dispatchToken]);
+ *       // `CountryStore.country` is now guaranteed to be updated.
+ *
+ *       // Select the default city for the new country
+ *       CityStore.city = getDefaultCityForCountry(CountryStore.country);
+ *     }
+ *   });
+ *
+ * The usage of `waitFor()` can be chained, for example:
+ *
+ *   FlightPriceStore.dispatchToken =
+ *     flightDispatcher.register(function(payload) {
+ *       switch (payload.actionType) {
+ *         case 'country-update':
+ *           flightDispatcher.waitFor([CityStore.dispatchToken]);
+ *           FlightPriceStore.price =
+ *             getFlightPriceStore(CountryStore.country, CityStore.city);
+ *           break;
+ *
+ *         case 'city-update':
+ *           FlightPriceStore.price =
+ *             FlightPriceStore(CountryStore.country, CityStore.city);
+ *           break;
+ *     }
+ *   });
+ *
+ * The `country-update` payload will be guaranteed to invoke the stores'
+ * registered callbacks in order: `CountryStore`, `CityStore`, then
+ * `FlightPriceStore`.
+ */
+
+  function Dispatcher() {
+    this.$Dispatcher_callbacks = {};
+    this.$Dispatcher_isPending = {};
+    this.$Dispatcher_isHandled = {};
+    this.$Dispatcher_isDispatching = false;
+    this.$Dispatcher_pendingPayload = null;
+  }
+
+  /**
+   * Registers a callback to be invoked with every dispatched payload. Returns
+   * a token that can be used with `waitFor()`.
+   *
+   * @param {function} callback
+   * @return {string}
+   */
+  Dispatcher.prototype.register=function(callback) {
+    var id = _prefix + _lastID++;
+    this.$Dispatcher_callbacks[id] = callback;
+    return id;
+  };
+
+  /**
+   * Removes a callback based on its token.
+   *
+   * @param {string} id
+   */
+  Dispatcher.prototype.unregister=function(id) {
+    invariant(
+      this.$Dispatcher_callbacks[id],
+      'Dispatcher.unregister(...): `%s` does not map to a registered callback.',
+      id
+    );
+    delete this.$Dispatcher_callbacks[id];
+  };
+
+  /**
+   * Waits for the callbacks specified to be invoked before continuing execution
+   * of the current callback. This method should only be used by a callback in
+   * response to a dispatched payload.
+   *
+   * @param {array<string>} ids
+   */
+  Dispatcher.prototype.waitFor=function(ids) {
+    invariant(
+      this.$Dispatcher_isDispatching,
+      'Dispatcher.waitFor(...): Must be invoked while dispatching.'
+    );
+    for (var ii = 0; ii < ids.length; ii++) {
+      var id = ids[ii];
+      if (this.$Dispatcher_isPending[id]) {
+        invariant(
+          this.$Dispatcher_isHandled[id],
+          'Dispatcher.waitFor(...): Circular dependency detected while ' +
+          'waiting for `%s`.',
+          id
+        );
+        continue;
+      }
+      invariant(
+        this.$Dispatcher_callbacks[id],
+        'Dispatcher.waitFor(...): `%s` does not map to a registered callback.',
+        id
+      );
+      this.$Dispatcher_invokeCallback(id);
+    }
+  };
+
+  /**
+   * Dispatches a payload to all registered callbacks.
+   *
+   * @param {object} payload
+   */
+  Dispatcher.prototype.dispatch=function(payload) {
+    invariant(
+      !this.$Dispatcher_isDispatching,
+      'Dispatch.dispatch(...): Cannot dispatch in the middle of a dispatch.'
+    );
+    this.$Dispatcher_startDispatching(payload);
+    try {
+      for (var id in this.$Dispatcher_callbacks) {
+        if (this.$Dispatcher_isPending[id]) {
+          continue;
+        }
+        this.$Dispatcher_invokeCallback(id);
+      }
+    } finally {
+      this.$Dispatcher_stopDispatching();
+    }
+  };
+
+  /**
+   * Is this Dispatcher currently dispatching.
+   *
+   * @return {boolean}
+   */
+  Dispatcher.prototype.isDispatching=function() {
+    return this.$Dispatcher_isDispatching;
+  };
+
+  /**
+   * Call the callback stored with the given id. Also do some internal
+   * bookkeeping.
+   *
+   * @param {string} id
+   * @internal
+   */
+  Dispatcher.prototype.$Dispatcher_invokeCallback=function(id) {
+    this.$Dispatcher_isPending[id] = true;
+    this.$Dispatcher_callbacks[id](this.$Dispatcher_pendingPayload);
+    this.$Dispatcher_isHandled[id] = true;
+  };
+
+  /**
+   * Set up bookkeeping needed when dispatching.
+   *
+   * @param {object} payload
+   * @internal
+   */
+  Dispatcher.prototype.$Dispatcher_startDispatching=function(payload) {
+    for (var id in this.$Dispatcher_callbacks) {
+      this.$Dispatcher_isPending[id] = false;
+      this.$Dispatcher_isHandled[id] = false;
+    }
+    this.$Dispatcher_pendingPayload = payload;
+    this.$Dispatcher_isDispatching = true;
+  };
+
+  /**
+   * Clear bookkeeping used for dispatching.
+   *
+   * @internal
+   */
+  Dispatcher.prototype.$Dispatcher_stopDispatching=function() {
+    this.$Dispatcher_pendingPayload = null;
+    this.$Dispatcher_isDispatching = false;
+  };
+
+
+module.exports = Dispatcher;
+
+},{"./invariant":5}],5:[function(require,module,exports){
+/**
+ * Copyright (c) 2014, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule invariant
+ */
+
+"use strict";
+
+/**
+ * Use invariant() to assert state which your program assumes to be true.
+ *
+ * Provide sprintf-style format (only %s is supported) and arguments
+ * to provide information about what broke and what you were
+ * expecting.
+ *
+ * The invariant message will be stripped in production, but the invariant
+ * will remain to ensure logic does not differ in production.
+ */
+
+var invariant = function(condition, format, a, b, c, d, e, f) {
+  if (false) {
+    if (format === undefined) {
+      throw new Error('invariant requires an error message argument');
+    }
+  }
+
+  if (!condition) {
+    var error;
+    if (format === undefined) {
+      error = new Error(
+        'Minified exception occurred; use the non-minified dev environment ' +
+        'for the full error message and additional helpful warnings.'
+      );
+    } else {
+      var args = [a, b, c, d, e, f];
+      var argIndex = 0;
+      error = new Error(
+        'Invariant Violation: ' +
+        format.replace(/%s/g, function() { return args[argIndex++]; })
+      );
+    }
+
+    error.framesToPop = 1; // we don't care about invariant's own frame
+    throw error;
+  }
+};
+
+module.exports = invariant;
+
+},{}],6:[function(require,module,exports){
+'use strict';
+
+function ToObject(val) {
+	if (val == null) {
+		throw new TypeError('Object.assign cannot be called with null or undefined');
+	}
+
+	return Object(val);
+}
+
+module.exports = Object.assign || function (target, source) {
+	var from;
+	var keys;
+	var to = ToObject(target);
+
+	for (var s = 1; s < arguments.length; s++) {
+		from = arguments[s];
+		keys = Object.keys(Object(from));
+
+		for (var i = 0; i < keys.length; i++) {
+			to[keys[i]] = from[keys[i]];
+		}
+	}
+
+	return to;
+};
+
+},{}],7:[function(require,module,exports){
+"use strict";
+
+var _interopRequire = function (obj) { return obj && obj.__esModule ? obj["default"] : obj; };
+
+var _get = function get(object, property, receiver) { var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc && desc.writable) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };
+
+var _inherits = function (subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; };
+
+var _createClass = (function () { function defineProperties(target, props) { for (var key in props) { var prop = props[key]; prop.configurable = true; if (prop.value) prop.writable = true; } Object.defineProperties(target, props); } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
+var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } };
+
+var Dispatcher = require("flux").Dispatcher;
+
+var EventEmitter = _interopRequire(require("eventemitter3"));
+
+var Symbol = _interopRequire(require("es-symbol"));
+
+var assign = _interopRequire(require("object-assign"));
+
+var now = Date.now();
+var VariableSymbol = function (desc) {
+  return Symbol("" + now + "" + desc);
+};
+
+var ACTION_HANDLER = Symbol("action creator handler");
+var ACTION_KEY = Symbol("holds the actions uid symbol for listening");
+var ACTION_UID = Symbol("the actions uid name");
+var EE = Symbol("event emitter instance");
+var INIT_SNAPSHOT = Symbol("init snapshot storage");
+var LAST_SNAPSHOT = Symbol("last snapshot storage");
+var LIFECYCLE = Symbol("store lifecycle listeners");
+var LISTENERS = Symbol("stores action listeners storage");
+var STATE_CONTAINER = VariableSymbol("the state container");
+
+var formatAsConstant = function (name) {
+  return name.replace(/[a-z]([A-Z])/g, function (i) {
+    return "" + i[0] + "_" + i[1].toLowerCase();
+  }).toUpperCase();
+};
+
+/* istanbul ignore next */
+function NoopClass() {}
+
+var builtIns = Object.getOwnPropertyNames(NoopClass);
+var builtInProto = Object.getOwnPropertyNames(NoopClass.prototype);
+
+var getInternalMethods = function (obj, excluded) {
+  return Object.getOwnPropertyNames(obj).reduce(function (value, m) {
+    if (excluded.indexOf(m) !== -1) {
+      return value;
+    }
+
+    value[m] = obj[m];
+    return value;
+  }, {});
+};
+
+var AltStore = (function () {
+  function AltStore(dispatcher, state) {
+    var _this6 = this;
+
+    _classCallCheck(this, AltStore);
+
+    this[EE] = new EventEmitter();
+    this[LIFECYCLE] = {};
+    this[STATE_CONTAINER] = state;
+
+    assign(this[LIFECYCLE], state[LIFECYCLE]);
+
+    // Register dispatcher
+    this.dispatchToken = dispatcher.register(function (payload) {
+      if (state[LISTENERS][payload.action]) {
+        var result = state[LISTENERS][payload.action](payload.data);
+        result !== false && _this6.emitChange();
+      }
+    });
+
+    if (this[LIFECYCLE].init) {
+      this[LIFECYCLE].init();
+    }
+  }
+
+  _createClass(AltStore, {
+    getEventEmitter: {
+      value: function getEventEmitter() {
+        return this[EE];
+      }
+    },
+    emitChange: {
+      value: function emitChange() {
+        this[EE].emit("change", this[STATE_CONTAINER]);
+      }
+    },
+    listen: {
+      value: function listen(cb) {
+        this[EE].on("change", cb);
+      }
+    },
+    unlisten: {
+      value: function unlisten(cb) {
+        this[EE].removeListener("change", cb);
+      }
+    },
+    getState: {
+      value: function getState() {
+        // Copy over state so it's RO.
+        return assign({}, this[STATE_CONTAINER]);
+      }
+    }
+  });
+
+  return AltStore;
+})();
+
+var ActionCreator = (function () {
+  function ActionCreator(alt, name, action, actions) {
+    _classCallCheck(this, ActionCreator);
+
+    this[ACTION_UID] = name;
+    this[ACTION_HANDLER] = action.bind(this);
+    this.actions = actions;
+    this.alt = alt;
+  }
+
+  _createClass(ActionCreator, {
+    dispatch: {
+      value: function dispatch(data) {
+        this.alt.dispatch(this[ACTION_UID], data);
+      }
+    }
+  });
+
+  return ActionCreator;
+})();
+
+var StoreMixin = {
+  on: function on(lifecycleEvent, handler) {
+    this[LIFECYCLE][lifecycleEvent] = handler.bind(this);
+  },
+
+  bindAction: function bindAction(symbol, handler) {
+    if (!symbol) {
+      throw new ReferenceError("Invalid action reference passed in");
+    }
+    if (typeof handler !== "function") {
+      throw new TypeError("bindAction expects a function");
+    }
+
+    if (handler.length > 1) {
+      throw new TypeError("Action handler in store " + this._storeName + " for " + ("" + (symbol[ACTION_KEY] || symbol).toString() + " was defined with 2 ") + "parameters. Only a single parameter is passed through the " + "dispatcher, did you mean to pass in an Object instead?");
+    }
+
+    // You can pass in the constant or the function itself
+    if (symbol[ACTION_KEY]) {
+      this[LISTENERS][symbol[ACTION_KEY]] = handler.bind(this);
+    } else {
+      this[LISTENERS][symbol] = handler.bind(this);
+    }
+  },
+
+  bindActions: function bindActions(actions) {
+    var _this6 = this;
+
+    Object.keys(actions).forEach(function (action) {
+      var symbol = actions[action];
+      var matchFirstCharacter = /./;
+      var assumedEventHandler = action.replace(matchFirstCharacter, function (x) {
+        return "on" + x[0].toUpperCase();
+      });
+      var handler = null;
+
+      if (_this6[action] && _this6[assumedEventHandler]) {
+        // If you have both action and onAction
+        throw new ReferenceError("You have multiple action handlers bound to an action: " + ("" + action + " and " + assumedEventHandler));
+      } else if (_this6[action]) {
+        // action
+        handler = _this6[action];
+      } else if (_this6[assumedEventHandler]) {
+        // onAction
+        handler = _this6[assumedEventHandler];
+      }
+
+      if (handler) {
+        _this6.bindAction(symbol, handler);
+      }
+    });
+  },
+
+  bindListeners: function bindListeners(obj) {
+    var _this6 = this;
+
+    Object.keys(obj).forEach(function (methodName) {
+      var symbol = obj[methodName];
+      var listener = _this6[methodName];
+
+      if (!listener) {
+        throw new ReferenceError("" + methodName + " defined but does not exist in " + _this6._storeName);
+      }
+
+      if (Array.isArray(symbol)) {
+        symbol.forEach(function (action) {
+          return _this6.bindAction(action, listener);
+        });
+      } else {
+        _this6.bindAction(symbol, listener);
+      }
+    });
+  },
+
+  waitFor: function waitFor(sources) {
+    if (!sources) {
+      throw new ReferenceError("Dispatch tokens not provided");
+    }
+
+    if (arguments.length === 1) {
+      sources = Array.isArray(sources) ? sources : [sources];
+    } else {
+      sources = Array.prototype.slice.call(arguments);
+    }
+
+    var tokens = sources.map(function (source) {
+      return source.dispatchToken || source;
+    });
+
+    this.dispatcher.waitFor(tokens);
+  }
+};
+
+var setAppState = function (instance, data, onStore) {
+  var obj = JSON.parse(data);
+  Object.keys(obj).forEach(function (key) {
+    assign(instance.stores[key][STATE_CONTAINER], obj[key]);
+    onStore(instance.stores[key]);
+  });
+};
+
+var snapshot = function (instance) {
+  return JSON.stringify(Object.keys(instance.stores).reduce(function (obj, key) {
+    if (instance.stores[key][LIFECYCLE].snapshot) {
+      instance.stores[key][LIFECYCLE].snapshot();
+    }
+    obj[key] = instance.stores[key].getState();
+    return obj;
+  }, {}));
+};
+
+var saveInitialSnapshot = function (instance, key) {
+  var state = instance.stores[key][STATE_CONTAINER];
+  var initial = JSON.parse(instance[INIT_SNAPSHOT]);
+  initial[key] = state;
+  instance[INIT_SNAPSHOT] = JSON.stringify(initial);
+};
+
+var filterSnapshotOfStores = function (snapshot, storeNames) {
+  var stores = JSON.parse(snapshot);
+  var storesToReset = storeNames.reduce(function (obj, name) {
+    if (!stores[name]) {
+      throw new ReferenceError("" + name + " is not a valid store");
+    }
+    obj[name] = stores[name];
+    return obj;
+  }, {});
+  return JSON.stringify(storesToReset);
+};
+
+var Alt = (function () {
+  function Alt() {
+    _classCallCheck(this, Alt);
+
+    this.dispatcher = new Dispatcher();
+    this.actions = {};
+    this.stores = {};
+    this[LAST_SNAPSHOT] = null;
+    this[INIT_SNAPSHOT] = "{}";
+  }
+
+  _createClass(Alt, {
+    dispatch: {
+      value: function dispatch(action, data) {
+        this.dispatcher.dispatch({ action: action, data: data });
+      }
+    },
+    createStore: {
+      value: function createStore(StoreModel, iden) {
+        var saveStore = arguments[2] === undefined ? true : arguments[2];
+
+        var storeInstance = undefined;
+        var key = iden || StoreModel.name || StoreModel.displayName || "";
+
+        if (saveStore && (this.stores[key] || !key)) {
+          /* istanbul ignore else */
+          if (typeof console !== "undefined") {
+            if (this.stores[key]) {
+              console.warn(new ReferenceError("A store named " + key + " already exists, double check your store " + "names or pass in your own custom identifier for each store"));
+            } else {
+              console.warn(new ReferenceError("Store name was not specified"));
+            }
+          }
+
+          // guarantee the store has a unique key name
+          var count = 0;
+          while (this.stores[key]) {
+            key = key + String(++count);
+          }
+        }
+
+        // Creating a class here so we don't overload the provided store's
+        // prototype with the mixin behaviour and I'm extending from StoreModel
+        // so we can inherit any extensions from the provided store.
+
+        var Store = (function (_StoreModel) {
+          function Store(alt) {
+            _classCallCheck(this, Store);
+
+            this[LIFECYCLE] = {};
+            this[LISTENERS] = {};
+            _get(Object.getPrototypeOf(Store.prototype), "constructor", this).call(this, alt);
+          }
+
+          _inherits(Store, _StoreModel);
+
+          return Store;
+        })(StoreModel);
+
+        assign(Store.prototype, StoreMixin, {
+          _storeName: key,
+          alt: this,
+          dispatcher: this.dispatcher,
+          getInstance: function getInstance() {
+            return storeInstance;
+          },
+          emitChange: function emitChange() {
+            this.getInstance().emitChange();
+          },
+          setState: function setState() {
+            var values = arguments[0] === undefined ? {} : arguments[0];
+
+            assign(this, values);
+            this.emitChange();
+            return false;
+          }
+        });
+
+        var store = new Store(this);
+
+        storeInstance = assign(new AltStore(this.dispatcher, store), getInternalMethods(StoreModel, builtIns));
+
+        if (saveStore) {
+          this.stores[key] = storeInstance;
+          saveInitialSnapshot(this, key);
+        }
+
+        return storeInstance;
+      }
+    },
+    generateActions: {
+      value: function generateActions() {
+        for (var _len = arguments.length, actionNames = Array(_len), _key = 0; _key < _len; _key++) {
+          actionNames[_key] = arguments[_key];
+        }
+
+        return this.createActions(function () {
+          var _ref;
+
+          (_ref = this).generateActions.apply(_ref, actionNames);
+        });
+      }
+    },
+    createActions: {
+      value: function createActions(ActionsClass) {
+        var _this6 = this;
+
+        var exportObj = arguments[1] === undefined ? {} : arguments[1];
+
+        var actions = assign({}, getInternalMethods(ActionsClass.prototype, builtInProto));
+        var key = ActionsClass.name || ActionsClass.displayName || "";
+
+        var ActionsGenerator = (function (_ActionsClass) {
+          function ActionsGenerator(alt) {
+            _classCallCheck(this, ActionsGenerator);
+
+            _get(Object.getPrototypeOf(ActionsGenerator.prototype), "constructor", this).call(this, alt);
+          }
+
+          _inherits(ActionsGenerator, _ActionsClass);
+
+          _createClass(ActionsGenerator, {
+            generateActions: {
+              value: function generateActions() {
+                for (var _len = arguments.length, actionNames = Array(_len), _key = 0; _key < _len; _key++) {
+                  actionNames[_key] = arguments[_key];
+                }
+
+                actionNames.forEach(function (actionName) {
+                  // This is a function so we can later bind this to ActionCreator
+                  actions[actionName] = function (x) {
+                    for (var _len2 = arguments.length, a = Array(_len2 > 1 ? _len2 - 1 : 0), _key2 = 1; _key2 < _len2; _key2++) {
+                      a[_key2 - 1] = arguments[_key2];
+                    }
+
+                    this.dispatch(a.length ? [x].concat(a) : x);
+                  };
+                });
+              }
+            }
+          });
+
+          return ActionsGenerator;
+        })(ActionsClass);
+
+        new ActionsGenerator(this);
+
+        return Object.keys(actions).reduce(function (obj, action) {
+          var constant = formatAsConstant(action);
+          var actionName = Symbol("" + key + "#" + action);
+
+          // Wrap the action so we can provide a dispatch method
+          var newAction = new ActionCreator(_this6, actionName, actions[action], obj);
+
+          // Set all the properties on action
+          obj[action] = newAction[ACTION_HANDLER];
+          obj[action].defer = function () {
+            for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+              args[_key] = arguments[_key];
+            }
+
+            setTimeout(function () {
+              return newAction[ACTION_HANDLER].apply(null, args);
+            });
+          };
+          obj[action][ACTION_KEY] = actionName;
+          obj[constant] = actionName;
+
+          return obj;
+        }, exportObj);
+      }
+    },
+    takeSnapshot: {
+      value: function takeSnapshot() {
+        var state = snapshot(this);
+        this[LAST_SNAPSHOT] = state;
+        return state;
+      }
+    },
+    rollback: {
+      value: function rollback() {
+        setAppState(this, this[LAST_SNAPSHOT], function (store) {
+          if (store[LIFECYCLE].rollback) {
+            store[LIFECYCLE].rollback();
+          }
+        });
+      }
+    },
+    recycle: {
+      value: function recycle() {
+        for (var _len = arguments.length, storeNames = Array(_len), _key = 0; _key < _len; _key++) {
+          storeNames[_key] = arguments[_key];
+        }
+
+        var snapshot = storeNames.length ? filterSnapshotOfStores(this[INIT_SNAPSHOT], storeNames) : this[INIT_SNAPSHOT];
+
+        setAppState(this, snapshot, function (store) {
+          if (store[LIFECYCLE].init) {
+            store[LIFECYCLE].init();
+          }
+        });
+      }
+    },
+    flush: {
+      value: function flush() {
+        var state = snapshot(this);
+        this.recycle();
+        return state;
+      }
+    },
+    bootstrap: {
+      value: function bootstrap(data) {
+        setAppState(this, data, function (store) {
+          if (store[LIFECYCLE].bootstrap) {
+            store[LIFECYCLE].bootstrap();
+          }
+        });
+      }
+    },
+    addActions: {
+
+      // Instance type methods for injecting alt into your application as context
+
+      value: function addActions(name, ActionsClass) {
+        this.actions[name] = this.createActions(ActionsClass);
+      }
+    },
+    addStore: {
+      value: function addStore(name, StoreModel, saveStore) {
+        this.createStore(StoreModel, name, saveStore);
+      }
+    },
+    getActions: {
+      value: function getActions(name) {
+        return this.actions[name];
+      }
+    },
+    getStore: {
+      value: function getStore(name) {
+        return this.stores[name];
+      }
+    }
+  });
+
+  return Alt;
+})();
+
+module.exports = Alt;
+
+},{"es-symbol":1,"eventemitter3":2,"flux":3,"object-assign":6}]},{},[7])(7)
+});

--- a/package.json
+++ b/package.json
@@ -13,16 +13,20 @@
     "babel": "^4.6.6",
     "coveralls": "^2.11.2",
     "istanbul": "^0.3.5",
-    "mocha": "^2.1.0"
+    "mocha": "^2.1.0",
+    "browserify": "^9.0.3",
+    "babelify": "^5.0.4"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/goatslacker/alt.git"
   },
   "scripts": {
-    "build": "npm run build-alt; npm run build-alt-runtime",
+    "build": "npm run build-alt; npm run build-alt-runtime; npm run build-alt-browser; npm run build-alt-browser-with-addons",
     "build-alt": "babel ./src/alt.js > dist/alt.js",
     "build-alt-runtime": "babel --external-helpers src/alt.js > dist/alt-with-runtime.js",
+    "build-alt-browser": "NODE_ENV=production browserify src/alt.js -t babelify --outfile dist/alt-browser.js --standalone Alt",
+    "build-alt-browser-with-addons": "NODE_ENV=production browserify src/alt-with-addons.js -t babelify --outfile dist/alt-browser-with-addons.js --standalone Alt",
     "coverage": "istanbul cover _mocha -- -u exports -R list --compilers js:babel/register --require babel/external-helpers test",
     "prepublish": "npm test",
     "test": "npm run build; npm run tests-all",

--- a/src/alt-with-addons.js
+++ b/src/alt-with-addons.js
@@ -1,0 +1,22 @@
+'use strict'
+
+import Alt from './alt'
+import ReactStateMagicMixin from '../mixins/ReactStateMagicMixin'
+import ListenerMixin from '../mixins/ListenerMixin'
+import FluxyMixin from '../mixins/FluxyMixin'
+import Subscribe from '../mixins/Subscribe'
+import ActionListeners from '../utils/ActionListeners'
+import DispatcherRecorder from '../utils/DispatcherRecorder'
+import makeFinalStore from '../utils/makeFinalStore'
+
+Alt.addons = {
+  ReactStateMagicMixin,
+  ListenerMixin,
+  FluxyMixin,
+  Subscribe,
+  ActionListeners,
+  DispatcherRecorder,
+  makeFinalStore
+}
+
+export default Alt

--- a/src/alt-with-addons.js
+++ b/src/alt-with-addons.js
@@ -1,22 +1,24 @@
 'use strict'
 
 import Alt from './alt'
-import ReactStateMagicMixin from '../mixins/ReactStateMagicMixin'
-import ListenerMixin from '../mixins/ListenerMixin'
+
 import FluxyMixin from '../mixins/FluxyMixin'
+import ListenerMixin from '../mixins/ListenerMixin'
+import ReactStateMagicMixin from '../mixins/ReactStateMagicMixin'
 import Subscribe from '../mixins/Subscribe'
+
 import ActionListeners from '../utils/ActionListeners'
 import DispatcherRecorder from '../utils/DispatcherRecorder'
 import makeFinalStore from '../utils/makeFinalStore'
 
 Alt.addons = {
-  ReactStateMagicMixin,
-  ListenerMixin,
-  FluxyMixin,
-  Subscribe,
   ActionListeners,
   DispatcherRecorder,
-  makeFinalStore
+  FluxyMixin,
+  ListenerMixin,
+  makeFinalStore,
+  ReactStateMagicMixin,
+  Subscribe
 }
 
 export default Alt


### PR DESCRIPTION
Uses browserify and babelify to assemble a bower-friendly standalone
version of Alt.

Updated bower's `main` to use the browser version, removed bower
dependencies block as they are now longer needed.