### PR TITLE
Add initial upgrade guide

### DIFF
--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -1,0 +1,3 @@
+# Upgrade Guide
+
+Use this as a reference to find the migration path for alt updates where breaking changes occur.


### PR DESCRIPTION
This was sparked from Issue #58, where we discussed changing the store API to explicitly provide public methods to the store instance, rather than magically providing them with `static` methods in the store class.

I think we should not shy away from breaking changes that improve alt (within reason), but we should definitely make it easy for users who are updating to find areas they need to modify to account for breaking changes in a new version.

A good example of this is in the [react-router](https://github.com/rackt/react-router/blob/master/UPGRADE_GUIDE.md) project.  I find that their upgrade guide is very helpful and provides a first place to look if things break when updating the library.