### PR TITLE
Update bootstrap docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Why you should be using Alt
 * It is pure [flux](http://facebook.github.io/flux/docs/overview.html).
 * It's [small](https://github.com/goatslacker/alt/blob/master/src/alt.js) and readable.
 * It is [terse](https://github.com/goatslacker/alt#no-boilerplate). No boilerplate.
-* Extremely [flexible](#flexibility) and unopionated in how you use flux.
+* Extremely [flexible](#flexibility) and unopinionated in how you use flux.
 * Alt is [forward thinking](#es6).
 * It's being used and actively maintained.
 
@@ -532,7 +532,7 @@ Restart the loop by making your views kick off new actions.
 `takeSnapshot :: String`
 
 Snapshots are a core component of alt. The idea is that at any given point in time you can `takeSnapshot` and have your entire application's state
-serialized for persistence, transfering, logging, or debugging.
+serialized for persistence, transferring, logging, or debugging.
 
 Taking a snapshot is as easy as calling `alt.takeSnapshot()`.
 
@@ -645,7 +645,7 @@ alt.createStore(class MyStore {
 ### Flexibility
 
 You can choose to use alt in many ways just like you'd use flux. This means your asynchronous data fetching can live in the actions, or they can live in the stores.
-Stores may also be traditional singletons as in flux, or you can create an instance and have multilple store copies. This leads us into server side rendering.
+Stores may also be traditional singletons as in flux, or you can create an instance and have multiple store copies. This leads us into server side rendering.
 
 ### Server Side Rendering
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ What's new.
 One really cool aspect of alt is that you can save snapshots of the entire application's state at any given point in time.
 Best of all, if you really screw the state up beyond repair you can easily rollback to the last saved snapshot.
 
-There's also a method available that lets you bootstrap all the application's stores once, at startup, with a saved snapshot.
+There's also a method available that lets you bootstrap all the application's stores with a saved snapshot (a JSON string).
 This is particularly useful if you're writing isomorphic applications where you can send down a snapshot of the state the server was in, then bootstrap it back on the client and continue working where the program left off.
 
 Store data is copied on retrieval. Meaning you can't just update the store through your store instance, the objects returned by `getState` are shallow copied so you won't accidentally mutate data and other stores can't mutate other stores. This makes it easy to reason about how your application exactly changes and where.
@@ -540,9 +540,9 @@ Taking a snapshot is as easy as calling `alt.takeSnapshot()`.
 
 `bootstrap :: String -> undefined`
 
-Bootstrapping can only be done once, and usually is best to do when initializing your application. The `alt.bootstrap()` function takes in a snapshot
+Bootstrapping can be done as many times as you wish, but it is common to use when initializing your application. The `alt.bootstrap()` function takes in a snapshot (JSON string)
 you've saved and reloads all the state with that snapshot, no events will be emitted to your components during this process, so again, it's best to do this
-on init before the view has even rendered.
+on init before the view has even rendered. If you need to emit a change event, you can use `this.emitChange` inside of your `bootstrap` life cycle method.
 
 Bootstrap is great if you're running an isomorphic app, or if you're persisting state to localstorage and then retrieving it on init later on. You can save a snapshot on the server side, send it down, and then bootstrap it back on the client.
 

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -11,6 +11,18 @@ permalink: /docs/bootstrap/
 
 The `alt.bootstrap()` function takes in a snapshot you've saved and reloads all the state with that snapshot, no events will be emitted to your components during this process, so it is advised to do this on init before the view has even rendered.
 
+If you need to emit a change event, you can use `this.emitChange` inside of your `bootstrap` life cycle method.
+
+```js
+class MyStore {
+  constructor() {
+    this.on('bootstrap', () =>
+      this.emitChange();
+    });
+  }
+}
+```
+
 Bootstrap is great if you're running an isomorphic app, or if you're persisting state to localstorage and then retrieving it on init later on. You can save a snapshot on the server side, send it down, and then bootstrap it back on the client.
 
 If you're bootstrapping then it is recommended you pass in a [unique Identifier to createStore](createStore.md#createstore), name of the class is good enough, to createStore so that it can be referenced later for bootstrapping.

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -11,7 +11,7 @@ permalink: /docs/bootstrap/
 
 The `alt.bootstrap()` function takes in a snapshot you've saved and reloads all the state with that snapshot, no events will be emitted to your components during this process, so it is advised to do this on init before the view has even rendered.
 
-If you need to emit a change event, you can use `this.emitChange` inside of your `bootstrap` life cycle method.
+If you want to emit a change event after bootstrapping you can use [`this.emitChange`](stores.md#storeemitchange) inside of the [bootstrap lifecycle method](lifecycleListeners.md#bootstrap).
 
 ```js
 class MyStore {


### PR DESCRIPTION
 - Docs reference that bootstrap can only be done once, which is no  longer true thanks to this commit 0ba7b85
- Fix a few spelling mistakes in README