### PR TITLE
Add deserialize lifecycle hook

### DIFF
--- a/dist/alt-browser-with-addons.js
+++ b/dist/alt-browser-with-addons.js
@@ -1237,17 +1237,35 @@ var StoreMixin = {
 var setAppState = function (instance, data, onStore) {
   var obj = JSON.parse(data);
   Object.keys(obj).forEach(function (key) {
-    assign(instance.stores[key][STATE_CONTAINER], obj[key]);
-    onStore(instance.stores[key]);
+    var store = instance.stores[key];
+    if (store[LIFECYCLE].deserialize) {
+      obj[key] = store[LIFECYCLE].deserialize(obj[key]);
+      /* istanbul ignore next */
+      if (!obj[key]) {
+        throw new Error("The \"deserialize\" lifecycle method in the store, " + key + ", must return data.");
+      }
+    }
+    assign(store[STATE_CONTAINER], obj[key]);
+    onStore(store);
   });
 };
 
 var snapshot = function (instance) {
   return JSON.stringify(Object.keys(instance.stores).reduce(function (obj, key) {
-    if (instance.stores[key][LIFECYCLE].snapshot) {
-      instance.stores[key][LIFECYCLE].snapshot();
+    var store = instance.stores[key];
+    if (store[LIFECYCLE].snapshot) {
+      store[LIFECYCLE].snapshot();
     }
-    obj[key] = instance.stores[key].getState();
+
+    if (store[LIFECYCLE].serialize) {
+      obj[key] = store[LIFECYCLE].serialize();
+      /* istanbul ignore next */
+      if (!obj[key]) {
+        throw new Error("The \"serialize\" lifecycle method in the store, " + key + ", must return data.");
+      }
+    } else {
+      obj[key] = store.getState();
+    }
     return obj;
   }, {}));
 };

--- a/dist/alt-browser-with-addons.js
+++ b/dist/alt-browser-with-addons.js
@@ -1249,10 +1249,7 @@ var setAppState = function (instance, data, onStore) {
 var snapshot = function (instance) {
   return JSON.stringify(Object.keys(instance.stores).reduce(function (obj, key) {
     var store = instance.stores[key];
-    var customSnapshot = undefined;
-    if (store[LIFECYCLE].snapshot) {
-      customSnapshot = store[LIFECYCLE].snapshot();
-    }
+    var customSnapshot = store[LIFECYCLE].snapshot && store[LIFECYCLE].snapshot();
     obj[key] = customSnapshot ? customSnapshot : store.getState();
     return obj;
   }, {}));

--- a/dist/alt-browser-with-addons.js
+++ b/dist/alt-browser-with-addons.js
@@ -1253,19 +1253,11 @@ var setAppState = function (instance, data, onStore) {
 var snapshot = function (instance) {
   return JSON.stringify(Object.keys(instance.stores).reduce(function (obj, key) {
     var store = instance.stores[key];
+    var customSnapshot = undefined;
     if (store[LIFECYCLE].snapshot) {
-      store[LIFECYCLE].snapshot();
+      customSnapshot = store[LIFECYCLE].snapshot();
     }
-
-    if (store[LIFECYCLE].serialize) {
-      obj[key] = store[LIFECYCLE].serialize();
-      /* istanbul ignore next */
-      if (!obj[key]) {
-        throw new Error("The \"serialize\" lifecycle method in the store, " + key + ", must return data.");
-      }
-    } else {
-      obj[key] = store.getState();
-    }
+    obj[key] = customSnapshot ? customSnapshot : store.getState();
     return obj;
   }, {}));
 };

--- a/dist/alt-browser-with-addons.js
+++ b/dist/alt-browser-with-addons.js
@@ -1239,11 +1239,7 @@ var setAppState = function (instance, data, onStore) {
   Object.keys(obj).forEach(function (key) {
     var store = instance.stores[key];
     if (store[LIFECYCLE].deserialize) {
-      obj[key] = store[LIFECYCLE].deserialize(obj[key]);
-      /* istanbul ignore next */
-      if (!obj[key]) {
-        throw new Error("The \"deserialize\" lifecycle method in the store, " + key + ", must return data.");
-      }
+      obj[key] = store[LIFECYCLE].deserialize(obj[key]) || obj[key];
     }
     assign(store[STATE_CONTAINER], obj[key]);
     onStore(store);

--- a/dist/alt-browser.js
+++ b/dist/alt-browser.js
@@ -983,11 +983,7 @@ var setAppState = function (instance, data, onStore) {
   Object.keys(obj).forEach(function (key) {
     var store = instance.stores[key];
     if (store[LIFECYCLE].deserialize) {
-      obj[key] = store[LIFECYCLE].deserialize(obj[key]);
-      /* istanbul ignore next */
-      if (!obj[key]) {
-        throw new Error("The \"deserialize\" lifecycle method in the store, " + key + ", must return data.");
-      }
+      obj[key] = store[LIFECYCLE].deserialize(obj[key]) || obj[key];
     }
     assign(store[STATE_CONTAINER], obj[key]);
     onStore(store);

--- a/dist/alt-browser.js
+++ b/dist/alt-browser.js
@@ -997,19 +997,11 @@ var setAppState = function (instance, data, onStore) {
 var snapshot = function (instance) {
   return JSON.stringify(Object.keys(instance.stores).reduce(function (obj, key) {
     var store = instance.stores[key];
+    var customSnapshot = undefined;
     if (store[LIFECYCLE].snapshot) {
-      store[LIFECYCLE].snapshot();
+      customSnapshot = store[LIFECYCLE].snapshot();
     }
-
-    if (store[LIFECYCLE].serialize) {
-      obj[key] = store[LIFECYCLE].serialize();
-      /* istanbul ignore next */
-      if (!obj[key]) {
-        throw new Error("The \"serialize\" lifecycle method in the store, " + key + ", must return data.");
-      }
-    } else {
-      obj[key] = store.getState();
-    }
+    obj[key] = customSnapshot ? customSnapshot : store.getState();
     return obj;
   }, {}));
 };

--- a/dist/alt-browser.js
+++ b/dist/alt-browser.js
@@ -993,10 +993,7 @@ var setAppState = function (instance, data, onStore) {
 var snapshot = function (instance) {
   return JSON.stringify(Object.keys(instance.stores).reduce(function (obj, key) {
     var store = instance.stores[key];
-    var customSnapshot = undefined;
-    if (store[LIFECYCLE].snapshot) {
-      customSnapshot = store[LIFECYCLE].snapshot();
-    }
+    var customSnapshot = store[LIFECYCLE].snapshot && store[LIFECYCLE].snapshot();
     obj[key] = customSnapshot ? customSnapshot : store.getState();
     return obj;
   }, {}));

--- a/dist/alt-browser.js
+++ b/dist/alt-browser.js
@@ -981,17 +981,35 @@ var StoreMixin = {
 var setAppState = function (instance, data, onStore) {
   var obj = JSON.parse(data);
   Object.keys(obj).forEach(function (key) {
-    assign(instance.stores[key][STATE_CONTAINER], obj[key]);
-    onStore(instance.stores[key]);
+    var store = instance.stores[key];
+    if (store[LIFECYCLE].deserialize) {
+      obj[key] = store[LIFECYCLE].deserialize(obj[key]);
+      /* istanbul ignore next */
+      if (!obj[key]) {
+        throw new Error("The \"deserialize\" lifecycle method in the store, " + key + ", must return data.");
+      }
+    }
+    assign(store[STATE_CONTAINER], obj[key]);
+    onStore(store);
   });
 };
 
 var snapshot = function (instance) {
   return JSON.stringify(Object.keys(instance.stores).reduce(function (obj, key) {
-    if (instance.stores[key][LIFECYCLE].snapshot) {
-      instance.stores[key][LIFECYCLE].snapshot();
+    var store = instance.stores[key];
+    if (store[LIFECYCLE].snapshot) {
+      store[LIFECYCLE].snapshot();
     }
-    obj[key] = instance.stores[key].getState();
+
+    if (store[LIFECYCLE].serialize) {
+      obj[key] = store[LIFECYCLE].serialize();
+      /* istanbul ignore next */
+      if (!obj[key]) {
+        throw new Error("The \"serialize\" lifecycle method in the store, " + key + ", must return data.");
+      }
+    } else {
+      obj[key] = store.getState();
+    }
     return obj;
   }, {}));
 };

--- a/dist/alt-with-runtime.js
+++ b/dist/alt-with-runtime.js
@@ -250,11 +250,7 @@ var setAppState = function (instance, data, onStore) {
   Object.keys(obj).forEach(function (key) {
     var store = instance.stores[key];
     if (store[LIFECYCLE].deserialize) {
-      obj[key] = store[LIFECYCLE].deserialize(obj[key]);
-      /* istanbul ignore next */
-      if (!obj[key]) {
-        throw new Error("The \"deserialize\" lifecycle method in the store, " + key + ", must return data.");
-      }
+      obj[key] = store[LIFECYCLE].deserialize(obj[key]) || obj[key];
     }
     assign(store[STATE_CONTAINER], obj[key]);
     onStore(store);

--- a/dist/alt-with-runtime.js
+++ b/dist/alt-with-runtime.js
@@ -248,17 +248,35 @@ var StoreMixin = {
 var setAppState = function (instance, data, onStore) {
   var obj = JSON.parse(data);
   Object.keys(obj).forEach(function (key) {
-    assign(instance.stores[key][STATE_CONTAINER], obj[key]);
-    onStore(instance.stores[key]);
+    var store = instance.stores[key];
+    if (store[LIFECYCLE].deserialize) {
+      obj[key] = store[LIFECYCLE].deserialize(obj[key]);
+      /* istanbul ignore next */
+      if (!obj[key]) {
+        throw new Error("The \"deserialize\" lifecycle method in the store, " + key + ", must return data.");
+      }
+    }
+    assign(store[STATE_CONTAINER], obj[key]);
+    onStore(store);
   });
 };
 
 var snapshot = function (instance) {
   return JSON.stringify(Object.keys(instance.stores).reduce(function (obj, key) {
-    if (instance.stores[key][LIFECYCLE].snapshot) {
-      instance.stores[key][LIFECYCLE].snapshot();
+    var store = instance.stores[key];
+    if (store[LIFECYCLE].snapshot) {
+      store[LIFECYCLE].snapshot();
     }
-    obj[key] = instance.stores[key].getState();
+
+    if (store[LIFECYCLE].serialize) {
+      obj[key] = store[LIFECYCLE].serialize();
+      /* istanbul ignore next */
+      if (!obj[key]) {
+        throw new Error("The \"serialize\" lifecycle method in the store, " + key + ", must return data.");
+      }
+    } else {
+      obj[key] = store.getState();
+    }
     return obj;
   }, {}));
 };

--- a/dist/alt-with-runtime.js
+++ b/dist/alt-with-runtime.js
@@ -264,19 +264,11 @@ var setAppState = function (instance, data, onStore) {
 var snapshot = function (instance) {
   return JSON.stringify(Object.keys(instance.stores).reduce(function (obj, key) {
     var store = instance.stores[key];
+    var customSnapshot = undefined;
     if (store[LIFECYCLE].snapshot) {
-      store[LIFECYCLE].snapshot();
+      customSnapshot = store[LIFECYCLE].snapshot();
     }
-
-    if (store[LIFECYCLE].serialize) {
-      obj[key] = store[LIFECYCLE].serialize();
-      /* istanbul ignore next */
-      if (!obj[key]) {
-        throw new Error("The \"serialize\" lifecycle method in the store, " + key + ", must return data.");
-      }
-    } else {
-      obj[key] = store.getState();
-    }
+    obj[key] = customSnapshot ? customSnapshot : store.getState();
     return obj;
   }, {}));
 };

--- a/dist/alt-with-runtime.js
+++ b/dist/alt-with-runtime.js
@@ -260,10 +260,7 @@ var setAppState = function (instance, data, onStore) {
 var snapshot = function (instance) {
   return JSON.stringify(Object.keys(instance.stores).reduce(function (obj, key) {
     var store = instance.stores[key];
-    var customSnapshot = undefined;
-    if (store[LIFECYCLE].snapshot) {
-      customSnapshot = store[LIFECYCLE].snapshot();
-    }
+    var customSnapshot = store[LIFECYCLE].snapshot && store[LIFECYCLE].snapshot();
     obj[key] = customSnapshot ? customSnapshot : store.getState();
     return obj;
   }, {}));

--- a/dist/alt.js
+++ b/dist/alt.js
@@ -264,11 +264,7 @@ var setAppState = function (instance, data, onStore) {
   Object.keys(obj).forEach(function (key) {
     var store = instance.stores[key];
     if (store[LIFECYCLE].deserialize) {
-      obj[key] = store[LIFECYCLE].deserialize(obj[key]);
-      /* istanbul ignore next */
-      if (!obj[key]) {
-        throw new Error("The \"deserialize\" lifecycle method in the store, " + key + ", must return data.");
-      }
+      obj[key] = store[LIFECYCLE].deserialize(obj[key]) || obj[key];
     }
     assign(store[STATE_CONTAINER], obj[key]);
     onStore(store);

--- a/dist/alt.js
+++ b/dist/alt.js
@@ -274,10 +274,7 @@ var setAppState = function (instance, data, onStore) {
 var snapshot = function (instance) {
   return JSON.stringify(Object.keys(instance.stores).reduce(function (obj, key) {
     var store = instance.stores[key];
-    var customSnapshot = undefined;
-    if (store[LIFECYCLE].snapshot) {
-      customSnapshot = store[LIFECYCLE].snapshot();
-    }
+    var customSnapshot = store[LIFECYCLE].snapshot && store[LIFECYCLE].snapshot();
     obj[key] = customSnapshot ? customSnapshot : store.getState();
     return obj;
   }, {}));

--- a/dist/alt.js
+++ b/dist/alt.js
@@ -278,19 +278,11 @@ var setAppState = function (instance, data, onStore) {
 var snapshot = function (instance) {
   return JSON.stringify(Object.keys(instance.stores).reduce(function (obj, key) {
     var store = instance.stores[key];
+    var customSnapshot = undefined;
     if (store[LIFECYCLE].snapshot) {
-      store[LIFECYCLE].snapshot();
+      customSnapshot = store[LIFECYCLE].snapshot();
     }
-
-    if (store[LIFECYCLE].serialize) {
-      obj[key] = store[LIFECYCLE].serialize();
-      /* istanbul ignore next */
-      if (!obj[key]) {
-        throw new Error("The \"serialize\" lifecycle method in the store, " + key + ", must return data.");
-      }
-    } else {
-      obj[key] = store.getState();
-    }
+    obj[key] = customSnapshot ? customSnapshot : store.getState();
     return obj;
   }, {}));
 };

--- a/docs/lifecycleListeners.md
+++ b/docs/lifecycleListeners.md
@@ -25,30 +25,15 @@ class Store {
 
 ## Snapshot
 
-`snapshot` is called before the store's state is serialized. Here you can perform any final tasks you need to before the state is saved.
+`snapshot` is called before the store's state is serialized. Here you can perform any final tasks you need to before the state is saved. You may optionally return an object, which will be used directly as the snapshot data for the store. If you do not return anything, the default, [`MyStore#getState()`](stores.md#storegetstate) is used for the snapshot data.
 
 ```js
 class Store {
   constructor() {
     this.on('snapshot', () => {
       // do something here
-    });
-  }
-}
-```
-
-## Serialize
-
-`serialize` is called when the store's state is being serialized. Here you can alter or limit the store data that you want to be included in the snapshot. The return value of this function is what gets used by alt in the snapshot. See the [serialization](serialization.md) for an example.
-
-**Serialize expects a return value or an error will be thrown if one is not present.**
-
-```js
-class Store {
-  constructor() {
-    this.on('serialize', () => {
-      // do something here
-      return obj
+      // optional return of data to be used in snapshot
+      // return mySnapshotData
     });
   }
 }

--- a/docs/lifecycleListeners.md
+++ b/docs/lifecycleListeners.md
@@ -41,9 +41,7 @@ class Store {
 
 ## Deserialize
 
-`deserialize` is called before the store's state is deserialized. This occurs whenever the store's state is being set to an existing snapshot/bootstrap data. Here you can perform any final tasks you need to before the snapshot/bootstrap data is set on the store such as mapping the data to model objects, or converting data an external source like a JSON API into a format the store expects. Deserialize takes in a parameter that is an object of snapshot/bootstrap data and must return the data to be set to the store's state. See the [serialization](serialization.md) for an example.
-
-**Deserialize expects a return value or an error will be thrown if one is not present.**
+`deserialize` is called before the store's state is deserialized. This occurs whenever the store's state is being set to an existing snapshot/bootstrap data. Here you can perform any final tasks you need to before the snapshot/bootstrap data is set on the store such as mapping the data to model objects, or converting data an external source like a JSON API into a format the store expects. Deserialize takes in a parameter that is an object of snapshot/bootstrap data and must return the data to be set to the store's state. If nothing is returned, then the data from the snapshot is set to the store's state. See the [serialization](serialization.md) for an example.
 
 ```js
 class Store {

--- a/docs/lifecycleListeners.md
+++ b/docs/lifecycleListeners.md
@@ -7,7 +7,7 @@ permalink: /docs/lifecycleListeners/
 
 # Lifecycle Listener Methods
 
-When bootstrapping, snapshotting, or recycling there are special methods you can assign to your store to ensure any bookeeping that needs to be done. You would place these in your store's constructor.
+When bootstrapping, snapshotting, or recycling there are special methods you can assign to your store to ensure any bookkeeping that needs to be done. You would place these in your store's constructor.
 
 ## Bootstrap
 
@@ -32,6 +32,40 @@ class Store {
   constructor() {
     this.on('snapshot', () => {
       // do something here
+    });
+  }
+}
+```
+
+## Serialize
+
+`serialize` is called when the store's state is being serialized. Here you can alter or limit the store data that you want to be included in the snapshot. The return value of this function is what gets used by alt in the snapshot. See the [serialization](serialization.md) for an example.
+
+**Serialize expects a return value or an error will be thrown if one is not present.**
+
+```js
+class Store {
+  constructor() {
+    this.on('serialize', () => {
+      // do something here
+      return obj
+    });
+  }
+}
+```
+
+## Deserialize
+
+`deserialize` is called before the store's state is deserialized. This occurs whenever the store's state is being set to an existing snapshot/bootstrap data. Here you can perform any final tasks you need to before the snapshot/bootstrap data is set on the store such as mapping the data to model objects, or converting data an external source like a JSON API into a format the store expects. Deserialize takes in a parameter that is an object of snapshot/bootstrap data and must return the data to be set to the store's state. See the [serialization](serialization.md) for an example.
+
+**Deserialize expects a return value or an error will be thrown if one is not present.**
+
+```js
+class Store {
+  constructor() {
+    this.on('deserialize', (data) => {
+      // do something here
+      return modifiedData
     });
   }
 }

--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -11,13 +11,13 @@ The [snapshot](lifecycleListeners.md#snapshot) and [deserialize](lifecycleListen
 
 In the example below, we will show how this technique can be used to `serialize` complex model data being used by the store into a simpler structure for the store's snapshot, and repopulate our store models with the simple structure from the bootstrap/snapshot data with `deserialize`.
 
-## Snapshot
+## Serialize
 
 `snapshot` provides a hook to transform the store data (via an optional return value) to be saved to an alt snapshot. If a return value is provided than it becomes the value of the store in the snapshot. For example, if the store name was `MyStore` and `serialize` returned `{firstName: 'Cereal', lastName: 'Eyes'}`, the snapshot would contain the data `{...'MyStore': {'firstName': 'Cereal', 'lastName': 'Eyes'}...}`. If there is no return value, the default, [`MyStore#getState()`](stores.md#storegetstate) is used for the snapshot data.
 
 ## Deserialize
 
-`deserialize` provides a hook to transform snapshot/bootstrap data into a form acceptable to the store for use within the application. The return value of this function becomes the state of the store. For example, if the `deserialize` received the data `{queryParams: 'val=2&val2=23'}`, we might transform the data into `{val: 2, val2: 23}` and return it to set the store data such that `myStore.val === 2` and `myStore.val2 === 23`. Deserialize can be useful for converting data from an external source such as a JSON API into the format the store expects.
+`deserialize` provides a hook to transform snapshot/bootstrap data into a form acceptable to the store for use within the application. The return value of this function becomes the state of the store. If there is no return value, the state of the store from the snapshot is used verbatim. For example, if the `deserialize` received the data `{queryParams: 'val=2&val2=23'}`, we might transform the data into `{val: 2, val2: 23}` and return it to set the store data such that `myStore.val === 2` and `myStore.val2 === 23`. Deserialize can be useful for converting data from an external source such as a JSON API into the format the store expects.
 
 ## Example
 

--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -7,13 +7,13 @@ permalink: /docs/serialization/
 
 # Serialization
 
-The [serialize](lifecycleListeners.md#serialize) and [deserialize](lifecycleListeners.md#deserialize) lifecycle listener methods can be utilized separately or together to transform the store data being saved in a snapshot or the snapshot/bootstrap data being set to a store. Though they do not have to be used together, you can picture the parity between the two methods. You can transform the shape of your store data created in the snapshot with `serialize`, which might be to get your data in a format ready to be consumed by other services and use `deserialize` to transform this data back into the format that your store recognizes.
+The [snapshot](lifecycleListeners.md#snapshot) and [deserialize](lifecycleListeners.md#deserialize) lifecycle listener methods can be utilized separately or together to transform the store data being saved in a snapshot or the snapshot/bootstrap data being set to a store. Though they do not have to be used together, you can picture the parity between the two methods. You can transform the shape of your store data created in the snapshot with `snapshot`, which might be to get your data in a format ready to be consumed by other services and use `deserialize` to transform this data back into the format that your store recognizes.
 
 In the example below, we will show how this technique can be used to `serialize` complex model data being used by the store into a simpler structure for the store's snapshot, and repopulate our store models with the simple structure from the bootstrap/snapshot data with `deserialize`.
 
-## Serialize
+## Snapshot
 
-`serialize` provides a hook to transform the store data to be saved to an alt snapshot, application data persisted by alt. The return value of this function becomes the value of the store in the snapshot. For example, if the store name was `MyStore` and `serialize` returned `{firstName: 'Cereal', lastName: 'Eyes'}`, the snapshot would contain the data `{...'MyStore': {'firstName': 'Cereal', 'lastName': 'Eyes'}...}`
+`snapshot` provides a hook to transform the store data (via an optional return value) to be saved to an alt snapshot. If a return value is provided than it becomes the value of the store in the snapshot. For example, if the store name was `MyStore` and `serialize` returned `{firstName: 'Cereal', lastName: 'Eyes'}`, the snapshot would contain the data `{...'MyStore': {'firstName': 'Cereal', 'lastName': 'Eyes'}...}`. If there is no return value, the default, [`MyStore#getState()`](stores.md#storegetstate) is used for the snapshot data.
 
 ## Deserialize
 
@@ -58,7 +58,7 @@ class MyStore {
     // we don't want to save this data in the snapshot
     this.semiPrivateVal = 10
 
-    this.on('serialize', () => {
+    this.on('snapshot', () => {
       return {
         // provides product and sum data from the model getters in addition to x and y
         // this data would not be included by the default serialization (getState)

--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -1,0 +1,86 @@
+---
+layout: docs
+title: Serialization
+description: Serialization example
+permalink: /docs/serialization/
+---
+
+# Serialization
+
+The [serialize](lifecycleListeners.md#serialize) and [deserialize](lifecycleListeners.md#deserialize) lifecycle listener methods can be utilized separately or together to transform the store data being saved in a snapshot or the snapshot/bootstrap data being set to a store. Though they do not have to be used together, you can picture the parity between the two methods. You can transform the shape of your store data created in the snapshot with `serialize`, which might be to get your data in a format ready to be consumed by other services and use `deserialize` to transform this data back into the format that your store recognizes.
+
+In the example below, we will show how this technique can be used to `serialize` complex model data being used by the store into a simpler structure for the store's snapshot, and repopulate our store models with the simple structure from the bootstrap/snapshot data with `deserialize`.
+
+## Serialize
+
+`serialize` provides a hook to transform the store data to be saved to an alt snapshot, application data persisted by alt. The return value of this function becomes the value of the store in the snapshot. For example, if the store name was `MyStore` and `serialize` returned `{firstName: 'Cereal', lastName: 'Eyes'}`, the snapshot would contain the data `{...'MyStore': {'firstName': 'Cereal', 'lastName': 'Eyes'}...}`
+
+## Deserialize
+
+`deserialize` provides a hook to transform snapshot/bootstrap data into a form acceptable to the store for use within the application. The return value of this function becomes the state of the store. For example, if the `deserialize` received the data `{queryParams: 'val=2&val2=23'}`, we might transform the data into `{val: 2, val2: 23}` and return it to set the store data such that `myStore.val === 2` and `myStore.val2 === 23`. Deserialize can be useful for converting data from an external source such as a JSON API into the format the store expects.
+
+## Example
+
+```js
+// this is a model that our store uses to organize/manage data
+class MyModel {
+  constructor({x, y}) {
+    this.x = x
+    this.y = y
+  }
+
+  get sum() {
+    return this.x + this.y
+  }
+
+  get product() {
+    return this.x * this.y
+  }
+
+  get data() {
+    return {
+      x: this.x,
+      y: this.y,
+      sum: this.sum,
+      product: this.product
+    }
+  }
+}
+
+// our store
+class MyStore {
+  constructor() {
+
+    // our model is being used by the store
+    this.myModel = new Model({x: 2, y: 3})
+    // we want to change the property name of this value in the snapshot
+    this.anotherVal = 5
+    // we don't want to save this data in the snapshot
+    this.semiPrivateVal = 10
+
+    this.on('serialize', () => {
+      return {
+        // provides product and sum data from the model getters in addition to x and y
+        // this data would not be included by the default serialization (getState)
+        myModel: this.myModel.data,
+        // change property name in snapshot
+        newValKeyName: this.anotherVal
+      }
+    })
+
+    this.on('deserialize', (data) => {
+      const modifiedData = {
+        // need to take POJO and move data into the model our store expects
+        myModel: new MyModel({x: data.myModel.x, y: data.myModel.y}),
+        // change the property name back to what our store expects
+        anotherVal: data.newValKeyName
+      }
+      return modifiedData
+    })
+  }
+
+  static getMyModelData() {
+    return this.getState().myModel.data
+  }
+}
+```

--- a/src/alt.js
+++ b/src/alt.js
@@ -219,7 +219,7 @@ const StoreMixin = {
 const setAppState = (instance, data, onStore) => {
   const obj = JSON.parse(data)
   Object.keys(obj).forEach((key) => {
-    const store = instance.stores[key];
+    const store = instance.stores[key]
     if (store[LIFECYCLE].deserialize) {
       obj[key] = store[LIFECYCLE].deserialize(obj[key])
       /* istanbul ignore next */
@@ -237,23 +237,12 @@ const setAppState = (instance, data, onStore) => {
 const snapshot = (instance) => {
   return JSON.stringify(
     Object.keys(instance.stores).reduce((obj, key) => {
-      const store = instance.stores[key];
+      const store = instance.stores[key]
+      let customSnapshot
       if (store[LIFECYCLE].snapshot) {
-        store[LIFECYCLE].snapshot()
+        customSnapshot = store[LIFECYCLE].snapshot()
       }
-
-      if (store[LIFECYCLE].serialize) {
-        obj[key] = store[LIFECYCLE].serialize()
-        /* istanbul ignore next */
-        if(!obj[key]) {
-          throw new Error(
-            `The "serialize" lifecycle method in the store, ${key}, must return data.`
-          )
-        }
-      }
-      else {
-        obj[key] = store.getState()
-      }
+      obj[key] = customSnapshot ? customSnapshot : store.getState()
       return obj
     }, {})
   )

--- a/src/alt.js
+++ b/src/alt.js
@@ -232,10 +232,7 @@ const snapshot = (instance) => {
   return JSON.stringify(
     Object.keys(instance.stores).reduce((obj, key) => {
       const store = instance.stores[key]
-      let customSnapshot
-      if (store[LIFECYCLE].snapshot) {
-        customSnapshot = store[LIFECYCLE].snapshot()
-      }
+      const customSnapshot = store[LIFECYCLE].snapshot && store[LIFECYCLE].snapshot()
       obj[key] = customSnapshot ? customSnapshot : store.getState()
       return obj
     }, {})

--- a/src/alt.js
+++ b/src/alt.js
@@ -221,13 +221,7 @@ const setAppState = (instance, data, onStore) => {
   Object.keys(obj).forEach((key) => {
     const store = instance.stores[key]
     if (store[LIFECYCLE].deserialize) {
-      obj[key] = store[LIFECYCLE].deserialize(obj[key])
-      /* istanbul ignore next */
-      if(!obj[key]) {
-        throw new Error(
-          `The "deserialize" lifecycle method in the store, ${key}, must return data.`
-        )
-      }
+      obj[key] = store[LIFECYCLE].deserialize(obj[key]) || obj[key]
     }
     assign(store[STATE_CONTAINER], obj[key])
     onStore(store)

--- a/src/alt.js
+++ b/src/alt.js
@@ -219,18 +219,41 @@ const StoreMixin = {
 const setAppState = (instance, data, onStore) => {
   const obj = JSON.parse(data)
   Object.keys(obj).forEach((key) => {
-    assign(instance.stores[key][STATE_CONTAINER], obj[key])
-    onStore(instance.stores[key])
+    const store = instance.stores[key];
+    if (store[LIFECYCLE].deserialize) {
+      obj[key] = store[LIFECYCLE].deserialize(obj[key])
+      /* istanbul ignore next */
+      if(!obj[key]) {
+        throw new Error(
+          `The "deserialize" lifecycle method in the store, ${key}, must return data.`
+        )
+      }
+    }
+    assign(store[STATE_CONTAINER], obj[key])
+    onStore(store)
   })
 }
 
 const snapshot = (instance) => {
   return JSON.stringify(
     Object.keys(instance.stores).reduce((obj, key) => {
-      if (instance.stores[key][LIFECYCLE].snapshot) {
-        instance.stores[key][LIFECYCLE].snapshot()
+      const store = instance.stores[key];
+      if (store[LIFECYCLE].snapshot) {
+        store[LIFECYCLE].snapshot()
       }
-      obj[key] = instance.stores[key].getState()
+
+      if (store[LIFECYCLE].serialize) {
+        obj[key] = store[LIFECYCLE].serialize()
+        /* istanbul ignore next */
+        if(!obj[key]) {
+          throw new Error(
+            `The "serialize" lifecycle method in the store, ${key}, must return data.`
+          )
+        }
+      }
+      else {
+        obj[key] = store.getState()
+      }
       return obj
     }, {})
   )

--- a/test/index.js
+++ b/test/index.js
@@ -225,7 +225,6 @@ class LifeCycleStore {
     })
     this.on('deserialize', (data) => {
       data.deserialized = true
-      return data
     })
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -203,7 +203,6 @@ class LifeCycleStore {
     this.init = false
     this.rollback = false
     this.snapshotted = false
-    this.serialized = false
     this.deserialized = false
 
     this.bindListeners({
@@ -223,10 +222,6 @@ class LifeCycleStore {
     })
     this.on('rollback', () => {
       this.rollback = true
-    })
-    this.on('serialize', () => {
-      this.serialized = true
-      return this
     })
     this.on('deserialize', (data) => {
       data.deserialized = true
@@ -286,7 +281,7 @@ class InterceptSnapshotStore {
     this.anotherVal = 5
     this.privateVal = 10
 
-    this.on('serialize', () => {
+    this.on('snapshot', () => {
       return {
         modelData: this.modelData.data,
         anotherVal: this.anotherVal
@@ -403,7 +398,6 @@ const tests = {
     assert(lifecycleStore.getState().rollback === false, 'rollback has not been called')
     assert(lifecycleStore.getState().init === true, 'init gets called when store initializes')
     assert.equal(lifecycleStore.getState().deserialized, true, 'deserialize has not been called yet')
-    assert.equal(lifecycleStore.getState().serialized, false, 'serialize has not been called yet')
   },
 
   'snapshots and bootstrapping'() {
@@ -413,7 +407,6 @@ const tests = {
     const bootstrapReturnValue = alt.bootstrap(initialSnapshot)
     assert(bootstrapReturnValue === undefined, 'bootstrap returns nothing')
     assert(lifecycleStore.getState().bootstrapped === true, 'bootstrap was called and the life cycle event was triggered')
-    assert.equal(lifecycleStore.getState().serialized, true, 'serialize was called and the life cycle event was triggered')
     assert.equal(lifecycleStore.getState().snapshotted, true, 'snapshot was called and the life cycle event was triggered')
     assert.equal(lifecycleStore.getState().deserialized, true, 'deserialize was called and the life cycle event was triggered')
   },
@@ -481,7 +474,7 @@ const tests = {
     assert(JSON.parse(snapshot).MyStore.name === 'bear', 'the snapshot is not affected by action')
   },
 
-  'serializing/deserializing'(){
+  'serializing/deserializing snapshot/bootstrap data'(){
     myActions.updateAnotherVal(11)
     let snapshot = alt.takeSnapshot()
     const expectedSerializedData = {
@@ -493,7 +486,7 @@ const tests = {
       },
       anotherVal: 11
     }
-    // serializes data correctly
+    // serializes snapshot data correctly
     assert.deepEqual(JSON.parse(snapshot).InterceptSnapshotStore, expectedSerializedData, 'interceptSnapshotStore was serialized correctly')
     alt.rollback()
     // deserializes data correctly

--- a/test/index.js
+++ b/test/index.js
@@ -20,7 +20,8 @@ class MyActions {
       'moreActions2',
       'moreActions3',
       'resetRecycled',
-      'asyncStoreAction'
+      'asyncStoreAction',
+      'updateAnotherVal'
     )
     this.generateActions('anotherAction')
   }
@@ -202,6 +203,8 @@ class LifeCycleStore {
     this.init = false
     this.rollback = false
     this.snapshotted = false
+    this.serialized = false
+    this.deserialized = false
 
     this.bindListeners({
       test: myActions.updateName,
@@ -220,6 +223,14 @@ class LifeCycleStore {
     })
     this.on('rollback', () => {
       this.rollback = true
+    })
+    this.on('serialize', () => {
+      this.serialized = true
+      return this
+    })
+    this.on('deserialize', (data) => {
+      data.deserialized = true
+      return data
     })
   }
 
@@ -242,6 +253,65 @@ class ThirdStore {
 }
 
 const thirdStore = alt.createStore(ThirdStore)
+
+class Model {
+  constructor({x, y}) {
+    this.x = x
+    this.y = y
+  }
+
+  get sum() {
+    return this.x + this.y
+  }
+
+  get product() {
+    return this.x * this.y
+  }
+
+  get data() {
+    return {
+      x: this.x,
+      y: this.y,
+      sum: this.sum,
+      product: this.product
+    }
+  }
+}
+
+class InterceptSnapshotStore {
+  constructor() {
+    this.bindAction(myActions.updateAnotherVal, this.onUpdateAnotherVal)
+
+    this.modelData = new Model({x: 2, y: 3})
+    this.anotherVal = 5
+    this.privateVal = 10
+
+    this.on('serialize', () => {
+      return {
+        modelData: this.modelData.data,
+        anotherVal: this.anotherVal
+      }
+    })
+
+    this.on('deserialize', (data) => {
+      const obj = {
+        modelData: new Model({x: data.modelData.x, y: data.modelData.y}),
+        anotherVal: data.anotherVal
+      }
+      return obj
+    })
+  }
+
+  onUpdateAnotherVal(newVal) {
+    this.anotherVal = newVal
+  }
+
+  static getModelData() {
+    return this.getState().modelData.data
+  }
+}
+
+let interceptSnapshotStore = alt.createStore(InterceptSnapshotStore)
 
 // Alt instances...
 
@@ -332,6 +402,8 @@ const tests = {
     assert(lifecycleStore.getState().snapshotted === false, 'takeSnapshot has not been called yet')
     assert(lifecycleStore.getState().rollback === false, 'rollback has not been called')
     assert(lifecycleStore.getState().init === true, 'init gets called when store initializes')
+    assert.equal(lifecycleStore.getState().deserialized, true, 'deserialize has not been called yet')
+    assert.equal(lifecycleStore.getState().serialized, false, 'serialize has not been called yet')
   },
 
   'snapshots and bootstrapping'() {
@@ -341,6 +413,9 @@ const tests = {
     const bootstrapReturnValue = alt.bootstrap(initialSnapshot)
     assert(bootstrapReturnValue === undefined, 'bootstrap returns nothing')
     assert(lifecycleStore.getState().bootstrapped === true, 'bootstrap was called and the life cycle event was triggered')
+    assert.equal(lifecycleStore.getState().serialized, true, 'serialize was called and the life cycle event was triggered')
+    assert.equal(lifecycleStore.getState().snapshotted, true, 'snapshot was called and the life cycle event was triggered')
+    assert.equal(lifecycleStore.getState().deserialized, true, 'deserialize was called and the life cycle event was triggered')
   },
 
   'existence of actions'() {
@@ -406,6 +481,25 @@ const tests = {
     assert(JSON.parse(snapshot).MyStore.name === 'bear', 'the snapshot is not affected by action')
   },
 
+  'serializing/deserializing'(){
+    myActions.updateAnotherVal(11)
+    let snapshot = alt.takeSnapshot()
+    const expectedSerializedData = {
+      modelData: {
+        x: 2,
+        y: 3,
+        sum: 5,
+        product: 6
+      },
+      anotherVal: 11
+    }
+    // serializes data correctly
+    assert.deepEqual(JSON.parse(snapshot).InterceptSnapshotStore, expectedSerializedData, 'interceptSnapshotStore was serialized correctly')
+    alt.rollback()
+    // deserializes data correctly
+    assert.deepEqual(interceptSnapshotStore.getModelData(), expectedSerializedData.modelData)
+  },
+
   'mutation'() {
     const state = myStore.getState()
     state.name = 'foobar'
@@ -417,8 +511,8 @@ const tests = {
     const rollbackValue = alt.rollback()
     assert(rollbackValue === undefined, 'rollback returns nothing')
 
-    assert(myStore.getState().name === 'bear', 'state has been rolledback to last snapshot')
-    assert(lifecycleStore.getState().rollback === true, 'rollback lifecycle method was called')
+    assert.equal(myStore.getState().name, 'first', 'state has been rolledback to last snapshot')
+    assert.equal(lifecycleStore.getState().rollback, true, 'rollback lifecycle method was called')
   },
 
   'store listening'() {


### PR DESCRIPTION
- `deserialize` is called before bootstrap/snapshot data is set back to the store. this allows the data to be transformed into a format that  the store expects. the return data becomes the store's state.
- `snapshot` now allows an optional return value. this value is used as the snapshot data if provided, otherwise the default `Store#getState()` is used.
- see the docs for more information