### PR TITLE
Adds serialize/loadEvents to dispatcher recorder

### DIFF
--- a/dist/alt-browser.js
+++ b/dist/alt-browser.js
@@ -760,6 +760,8 @@ var LISTENERS = Symbol("stores action listeners storage");
 var PUBLIC_METHODS = Symbol("store public method storage");
 var STATE_CONTAINER = Symbol("the state container");
 
+var GlobalActionsNameRegistry = {};
+
 function formatAsConstant(name) {
   return name.replace(/[a-z]([A-Z])/g, function (i) {
     return "" + i[0] + "_" + i[1].toLowerCase();
@@ -1224,7 +1226,9 @@ var Alt = (function () {
 
         return Object.keys(actions).reduce(function (obj, action) {
           var constant = formatAsConstant(action);
-          var actionName = Symbol("" + key + "#" + action);
+          var actionId = uid(GlobalActionsNameRegistry, "" + key + "#" + action);
+          GlobalActionsNameRegistry[actionId] = 1;
+          var actionName = Symbol["for"](actionId);
 
           // Wrap the action so we can provide a dispatch method
           var newAction = new ActionCreator(_this8, actionName, actions[action], obj);

--- a/dist/alt-with-runtime.js
+++ b/dist/alt-with-runtime.js
@@ -17,6 +17,8 @@ var LISTENERS = Symbol("stores action listeners storage");
 var PUBLIC_METHODS = Symbol("store public method storage");
 var STATE_CONTAINER = Symbol("the state container");
 
+var GlobalActionsNameRegistry = {};
+
 function formatAsConstant(name) {
   return name.replace(/[a-z]([A-Z])/g, function (i) {
     return "" + i[0] + "_" + i[1].toLowerCase();
@@ -474,7 +476,9 @@ var Alt = (function () {
 
         return Object.keys(actions).reduce(function (obj, action) {
           var constant = formatAsConstant(action);
-          var actionName = Symbol("" + key + "#" + action);
+          var actionId = uid(GlobalActionsNameRegistry, "" + key + "#" + action);
+          GlobalActionsNameRegistry[actionId] = 1;
+          var actionName = Symbol["for"](actionId);
 
           // Wrap the action so we can provide a dispatch method
           var newAction = new ActionCreator(_this8, actionName, actions[action], obj);

--- a/dist/alt.js
+++ b/dist/alt.js
@@ -29,6 +29,8 @@ var LISTENERS = Symbol("stores action listeners storage");
 var PUBLIC_METHODS = Symbol("store public method storage");
 var STATE_CONTAINER = Symbol("the state container");
 
+var GlobalActionsNameRegistry = {};
+
 function formatAsConstant(name) {
   return name.replace(/[a-z]([A-Z])/g, function (i) {
     return "" + i[0] + "_" + i[1].toLowerCase();
@@ -491,7 +493,9 @@ var Alt = (function () {
 
         return Object.keys(actions).reduce(function (obj, action) {
           var constant = formatAsConstant(action);
-          var actionName = Symbol("" + key + "#" + action);
+          var actionId = uid(GlobalActionsNameRegistry, "" + key + "#" + action);
+          GlobalActionsNameRegistry[actionId] = 1;
+          var actionName = Symbol["for"](actionId);
 
           // Wrap the action so we can provide a dispatch method
           var newAction = new ActionCreator(_this8, actionName, actions[action], obj);

--- a/src/alt.js
+++ b/src/alt.js
@@ -16,6 +16,8 @@ const LISTENERS = Symbol('stores action listeners storage')
 const PUBLIC_METHODS = Symbol('store public method storage')
 const STATE_CONTAINER = Symbol('the state container')
 
+const GlobalActionsNameRegistry = {}
+
 function formatAsConstant(name) {
   return name.replace(/[a-z]([A-Z])/g, (i) => {
     return `${i[0]}_${i[1].toLowerCase()}`
@@ -428,7 +430,9 @@ class Alt {
 
     return Object.keys(actions).reduce((obj, action) => {
       const constant = formatAsConstant(action)
-      const actionName = Symbol(`${key}#${action}`)
+      const actionId = uid(GlobalActionsNameRegistry, `${key}#${action}`)
+      GlobalActionsNameRegistry[actionId] = 1
+      const actionName = Symbol.for(actionId)
 
       // Wrap the action so we can provide a dispatch method
       const newAction = new ActionCreator(

--- a/test/index.js
+++ b/test/index.js
@@ -815,6 +815,9 @@ const tests = {
       return alt.createActions(a)
     }())
 
+    let uaOnce = 0
+    let laOnce = 0
+
     class Store {
       constructor() {
         this.bindAction(ua.UPDATE, this.ua)
@@ -826,10 +829,12 @@ const tests = {
 
       ua() {
         this.a = 1
+        uaOnce += 1
       }
 
       la() {
         this.b = 1
+        laOnce += 1
       }
     }
 
@@ -842,6 +847,8 @@ const tests = {
 
     assert(state.a === 1, 'both actions were called')
     assert(state.b === 1, 'both actions were called')
+    assert.equal(uaOnce, 1, 'actions only called once')
+    assert.equal(laOnce, 1, 'actions only called once')
   },
 
   'dispatching from alt instance'() {

--- a/test/recorder.js
+++ b/test/recorder.js
@@ -90,7 +90,7 @@ export default {
       assert(store.getState().b === 0, 'store state is cleared')
       assert(store.getState().c === 0, 'store state is cleared')
 
-      recorder.replay(0, function () {
+      recorder.replay(0, () => {
         assert(store.getState().a === 'hello', 'store state is set')
         assert(store.getState().b === 'world', 'store state is set')
         assert(store.getState().c === 'it works', 'store state is set')
@@ -101,5 +101,43 @@ export default {
         done()
       })
     },
+
+    'serialize and deserialize events'() {
+      const recording = recorder.record()
+
+      actions.a('hello')
+      actions.b('world')
+      actions.c('it works')
+
+      recorder.stop()
+
+      assert.equal(store.getState().a, 'hello', 'store state is set')
+      assert.equal(store.getState().b, 'world', 'store state is set')
+      assert.equal(store.getState().c, 'it works', 'store state is set')
+
+      var serialized = recorder.serializeEvents()
+
+      assert.equal(typeof serialized, 'string', 'events were serialized')
+
+      const newRecorder = new DispatcherRecorder(alt)
+
+      assert.equal(newRecorder.events.length, 0, 'events are blank')
+
+      alt.recycle()
+
+      assert.equal(store.getState().a, 0, 'store state is cleared')
+      assert.equal(store.getState().b, 0, 'store state is cleared')
+      assert.equal(store.getState().c, 0, 'store state is cleared')
+
+      newRecorder.loadEvents(serialized)
+
+      assert.equal(newRecorder.events.length, 3, 'events are loaded')
+
+      newRecorder.replay()
+
+      assert.equal(store.getState().a, 'hello', 'store state is set')
+      assert.equal(store.getState().b, 'world', 'store state is set')
+      assert.equal(store.getState().c, 'it works', 'store state is set')
+    }
   }
 }

--- a/utils/DispatcherRecorder.js
+++ b/utils/DispatcherRecorder.js
@@ -28,6 +28,8 @@
  */
 module.exports = DispatcherRecorder
 
+var Symbol = require('es-symbol')
+
 function DispatcherRecorder(alt) {
   this.alt = alt
   this.events = []
@@ -35,9 +37,9 @@ function DispatcherRecorder(alt) {
 }
 
 /**
- * record(): boolean
  * If recording started you get true, otherwise false since there's a recording
  * in progress.
+ * record(): boolean
  */
 DispatcherRecorder.prototype.record = function () {
   if (this.dispatchToken) {
@@ -53,6 +55,7 @@ DispatcherRecorder.prototype.record = function () {
 
 /**
  * Stops the recording in progress.
+ * stop(): undefined
  */
 DispatcherRecorder.prototype.stop = function () {
   this.alt.dispatcher.unregister(this.dispatchToken)
@@ -61,6 +64,7 @@ DispatcherRecorder.prototype.stop = function () {
 
 /**
  * Clear all events from memory.
+ * clear(): undefined
  */
 DispatcherRecorder.prototype.clear = function () {
   this.events = []
@@ -97,4 +101,33 @@ DispatcherRecorder.prototype.replay = function (replayTime, done) {
   }
 
   next()
+}
+
+/**
+ * Serialize all the events so you can pass them around or load them into
+ * a separate recorder.
+ * serializeEvents(): string
+ */
+DispatcherRecorder.prototype.serializeEvents = function () {
+  var events = this.events.map(function (event) {
+    return {
+      action: Symbol.keyFor(event.action),
+      data: event.data
+    }
+  })
+  return JSON.stringify(events)
+}
+
+/**
+ * Load serialized events into the recorder and overwrite the current events
+ * loadEvents(events: string): undefined
+ */
+DispatcherRecorder.prototype.loadEvents = function (events) {
+  var parsedEvents = JSON.parse(events)
+  this.events = parsedEvents.map(function (event) {
+    return {
+      action: Symbol.for(event.action),
+      data: event.data
+    }
+  })
 }


### PR DESCRIPTION
This allows the serialization/deserialization of events when using the dispatcher recorder. Now it's able to intercept events and fire off actions later in separate alt apps even (provided the same code is running).