### PR TITLE
Allow `takeSnapshot` to specify stores

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ var locationActions = alt.generateActions('updateLocation', 'updateCity', 'updat
 
 Stores are where you keep a part of your application's state.
 
-`alt.createStore :: Class, String -> Store`
+`alt.createStore :: Class, string -> Store`
 
 ```js
 class LocationStore {
@@ -529,7 +529,7 @@ Restart the loop by making your views kick off new actions.
 
 ### Snapshots
 
-`takeSnapshot :: ?...String -> String`
+`takeSnapshot :: ?...string -> string`
 
 Snapshots are a core component of alt. The idea is that at any given point in time you can `takeSnapshot` and have your entire application's state
 serialized for persistence, transferring, logging, or debugging.
@@ -538,7 +538,7 @@ Taking a snapshot is as easy as calling `alt.takeSnapshot()`. It can also take a
 
 ### Bootstrapping
 
-`bootstrap :: String -> undefined`
+`bootstrap :: string -> undefined`
 
 Bootstrapping can be done as many times as you wish, but it is common to use when initializing your application. The `alt.bootstrap()` function takes in a snapshot (JSON string)
 you've saved and reloads all the state with that snapshot, no events will be emitted to your components during this process, so again, it's best to do this
@@ -561,13 +561,13 @@ that it's not automatic in case of errors, and it only rolls back to the last sa
 
 ### Flushing
 
-`flush :: String`
+`flush :: string`
 
 Flush takes a snapshot of the current state and then resets all the stores back to their original initial state. This is useful if you're using alt stores as singletons and doing server side rendering because of concurrency. In this particular scenario you would load the data in via `bootstrap` and then use `flush` to take a snapshot, render the data, and reset your stores so they are ready for the next request.
 
 ### Recycling
 
-`recycle :: ?...String -> undefined`
+`recycle :: ?...string -> undefined`
 
 If you wish to reset a particular, or all, store's state back to their original initial state you would call `recycle`. Recycle takes an optional number of arguments as strings which correspond to the store's names you would like reset. If no argument is provided then all stores are reset.
 

--- a/README.md
+++ b/README.md
@@ -529,12 +529,12 @@ Restart the loop by making your views kick off new actions.
 
 ### Snapshots
 
-`takeSnapshot :: String`
+`takeSnapshot :: ?...String -> String`
 
 Snapshots are a core component of alt. The idea is that at any given point in time you can `takeSnapshot` and have your entire application's state
 serialized for persistence, transferring, logging, or debugging.
 
-Taking a snapshot is as easy as calling `alt.takeSnapshot()`.
+Taking a snapshot is as easy as calling `alt.takeSnapshot()`. It can also take an optional number of arguments as strings which correspond to the store names you would like to include in the snapshot. This allows you to take a snapshot of a subset of your app's data.
 
 ### Bootstrapping
 

--- a/dist/alt-browser-with-addons.js
+++ b/dist/alt-browser-with-addons.js
@@ -1258,7 +1258,12 @@ var setAppState = function (instance, data, onStore) {
 };
 
 var snapshot = function (instance) {
-  return JSON.stringify(Object.keys(instance.stores).reduce(function (obj, key) {
+  for (var _len = arguments.length, storeNames = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+    storeNames[_key - 1] = arguments[_key];
+  }
+
+  var stores = storeNames.length ? storeNames : Object.keys(instance.stores);
+  return JSON.stringify(stores.reduce(function (obj, key) {
     var store = instance.stores[key];
     var customSnapshot = store[LIFECYCLE].serialize && store[LIFECYCLE].serialize();
     obj[key] = customSnapshot ? customSnapshot : store.getState();
@@ -1509,8 +1514,16 @@ var Alt = (function () {
     },
     takeSnapshot: {
       value: function takeSnapshot() {
-        var state = snapshot(this);
-        this[LAST_SNAPSHOT] = state;
+        for (var _len = arguments.length, storeNames = Array(_len), _key = 0; _key < _len; _key++) {
+          storeNames[_key] = arguments[_key];
+        }
+
+        var state = snapshot.apply(undefined, [this].concat(storeNames));
+        if (this[LAST_SNAPSHOT]) {
+          assign(this[LAST_SNAPSHOT], state);
+        } else {
+          this[LAST_SNAPSHOT] = state;
+        }
         return state;
       }
     },

--- a/dist/alt-browser-with-addons.js
+++ b/dist/alt-browser-with-addons.js
@@ -1,6 +1,5 @@
 (function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.Alt = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 "use strict";
-
 /**
  * This mixin lets you setup your listeners. It is similar to Fluxible's mixin.
  *
@@ -80,7 +79,6 @@ module.exports = FluxyMixin;
 
 },{"./Subscribe":4}],2:[function(require,module,exports){
 "use strict";
-
 var Subscribe = require("./Subscribe");
 
 var ListenerMixin = {
@@ -111,7 +109,6 @@ module.exports = ListenerMixin;
 
 },{"./Subscribe":4}],3:[function(require,module,exports){
 "use strict";
-
 /**
  * This mixin automatically sets the state for you based on the key you provide
  *
@@ -193,7 +190,6 @@ module.exports = ReactStateMagicMixin;
 
 },{"./Subscribe":4}],4:[function(require,module,exports){
 "use strict";
-
 var Symbol = require("es-symbol");
 var MIXIN_REGISTRY = Symbol("alt store listeners");
 
@@ -1435,9 +1431,7 @@ var Alt = (function () {
         }
 
         return this.createActions(function () {
-          var _ref;
-
-          (_ref = this).generateActions.apply(_ref, actionNames);
+          this.generateActions.apply(this, actionNames);
         });
       }
     },
@@ -1601,7 +1595,6 @@ module.exports = Alt;
 
 },{"es-symbol":5,"eventemitter3":6,"flux":7,"object-assign":10}],13:[function(require,module,exports){
 "use strict";
-
 /**
  * ActionListeners(alt: AltInstance): ActionListenersInstance
  *
@@ -1664,7 +1657,6 @@ ActionListeners.prototype.removeAllActionListeners = function () {
 
 },{"es-symbol":5}],14:[function(require,module,exports){
 "use strict";
-
 /**
  * DispatcherRecorder(alt: AltInstance): DispatcherInstance
  *
@@ -1800,7 +1792,6 @@ DispatcherRecorder.prototype.loadEvents = function (events) {
 
 },{"es-symbol":5}],15:[function(require,module,exports){
 "use strict";
-
 /**
  * makeFinalStore(alt: AltInstance): AltStore
  *

--- a/dist/alt-browser.js
+++ b/dist/alt-browser.js
@@ -1179,9 +1179,7 @@ var Alt = (function () {
         }
 
         return this.createActions(function () {
-          var _ref;
-
-          (_ref = this).generateActions.apply(_ref, actionNames);
+          this.generateActions.apply(this, actionNames);
         });
       }
     },

--- a/dist/alt-browser.js
+++ b/dist/alt-browser.js
@@ -1002,7 +1002,12 @@ var setAppState = function (instance, data, onStore) {
 };
 
 var snapshot = function (instance) {
-  return JSON.stringify(Object.keys(instance.stores).reduce(function (obj, key) {
+  for (var _len = arguments.length, storeNames = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+    storeNames[_key - 1] = arguments[_key];
+  }
+
+  var stores = storeNames.length ? storeNames : Object.keys(instance.stores);
+  return JSON.stringify(stores.reduce(function (obj, key) {
     var store = instance.stores[key];
     var customSnapshot = store[LIFECYCLE].serialize && store[LIFECYCLE].serialize();
     obj[key] = customSnapshot ? customSnapshot : store.getState();
@@ -1253,8 +1258,16 @@ var Alt = (function () {
     },
     takeSnapshot: {
       value: function takeSnapshot() {
-        var state = snapshot(this);
-        this[LAST_SNAPSHOT] = state;
+        for (var _len = arguments.length, storeNames = Array(_len), _key = 0; _key < _len; _key++) {
+          storeNames[_key] = arguments[_key];
+        }
+
+        var state = snapshot.apply(undefined, [this].concat(storeNames));
+        if (this[LAST_SNAPSHOT]) {
+          assign(this[LAST_SNAPSHOT], state);
+        } else {
+          this[LAST_SNAPSHOT] = state;
+        }
         return state;
       }
     },

--- a/dist/alt-with-runtime.js
+++ b/dist/alt-with-runtime.js
@@ -257,7 +257,12 @@ var setAppState = function (instance, data, onStore) {
 };
 
 var snapshot = function (instance) {
-  return JSON.stringify(Object.keys(instance.stores).reduce(function (obj, key) {
+  for (var _len = arguments.length, storeNames = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+    storeNames[_key - 1] = arguments[_key];
+  }
+
+  var stores = storeNames.length ? storeNames : Object.keys(instance.stores);
+  return JSON.stringify(stores.reduce(function (obj, key) {
     var store = instance.stores[key];
     var customSnapshot = store[LIFECYCLE].serialize && store[LIFECYCLE].serialize();
     obj[key] = customSnapshot ? customSnapshot : store.getState();
@@ -503,8 +508,16 @@ var Alt = (function () {
     },
     takeSnapshot: {
       value: function takeSnapshot() {
-        var state = snapshot(this);
-        this[LAST_SNAPSHOT] = state;
+        for (var _len = arguments.length, storeNames = Array(_len), _key = 0; _key < _len; _key++) {
+          storeNames[_key] = arguments[_key];
+        }
+
+        var state = snapshot.apply(undefined, [this].concat(storeNames));
+        if (this[LAST_SNAPSHOT]) {
+          assign(this[LAST_SNAPSHOT], state);
+        } else {
+          this[LAST_SNAPSHOT] = state;
+        }
         return state;
       }
     },

--- a/dist/alt.js
+++ b/dist/alt.js
@@ -271,7 +271,12 @@ var setAppState = function (instance, data, onStore) {
 };
 
 var snapshot = function (instance) {
-  return JSON.stringify(Object.keys(instance.stores).reduce(function (obj, key) {
+  for (var _len = arguments.length, storeNames = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+    storeNames[_key - 1] = arguments[_key];
+  }
+
+  var stores = storeNames.length ? storeNames : Object.keys(instance.stores);
+  return JSON.stringify(stores.reduce(function (obj, key) {
     var store = instance.stores[key];
     var customSnapshot = store[LIFECYCLE].serialize && store[LIFECYCLE].serialize();
     obj[key] = customSnapshot ? customSnapshot : store.getState();
@@ -520,8 +525,16 @@ var Alt = (function () {
     },
     takeSnapshot: {
       value: function takeSnapshot() {
-        var state = snapshot(this);
-        this[LAST_SNAPSHOT] = state;
+        for (var _len = arguments.length, storeNames = Array(_len), _key = 0; _key < _len; _key++) {
+          storeNames[_key] = arguments[_key];
+        }
+
+        var state = snapshot.apply(undefined, [this].concat(storeNames));
+        if (this[LAST_SNAPSHOT]) {
+          assign(this[LAST_SNAPSHOT], state);
+        } else {
+          this[LAST_SNAPSHOT] = state;
+        }
         return state;
       }
     },

--- a/docs/takeSnapshot.md
+++ b/docs/takeSnapshot.md
@@ -7,13 +7,14 @@ permalink: /docs/takeSnapshot/
 
 # takeSnapshot
 
-> (): string
+> (...storeNames: ?string): string
 
-Take snapshot provides you with the entire application's state serialized to JSON.
+Take snapshot provides you with the entire application's state serialized to JSON, by default, but you may also pass in store names to take a snapshot of a subset of the application's state.
 
 Snapshots are a core component of alt. The idea is that at any given point in time you can `takeSnapshot` and have your entire application's state
-serialized for persistence, transfering, logging, or debugging.
+serialized for persistence, transferring, logging, or debugging.
 
 ```js
 var snapshot = alt.takeSnapshot();
+var partialSnapshot = alt.takeSnapshot('Store1', 'Store3');
 ```

--- a/src/alt.js
+++ b/src/alt.js
@@ -459,10 +459,9 @@ class Alt {
 
   takeSnapshot(...storeNames) {
     const state = snapshot(this, ...storeNames)
-    if(this[LAST_SNAPSHOT]) {
+    if (this[LAST_SNAPSHOT]) {
       assign(this[LAST_SNAPSHOT], state)
-    }
-    else {
+    } else {
       this[LAST_SNAPSHOT] = state
     }
     return state

--- a/src/alt.js
+++ b/src/alt.js
@@ -239,9 +239,10 @@ const setAppState = (instance, data, onStore) => {
   })
 }
 
-const snapshot = (instance) => {
+const snapshot = (instance, ...storeNames) => {
+  const stores = storeNames.length ? storeNames : Object.keys(instance.stores)
   return JSON.stringify(
-    Object.keys(instance.stores).reduce((obj, key) => {
+    stores.reduce((obj, key) => {
       const store = instance.stores[key]
       const customSnapshot = store[LIFECYCLE].serialize && store[LIFECYCLE].serialize()
       obj[key] = customSnapshot ? customSnapshot : store.getState()
@@ -456,9 +457,14 @@ class Alt {
     }, exportObj)
   }
 
-  takeSnapshot() {
-    const state = snapshot(this)
-    this[LAST_SNAPSHOT] = state
+  takeSnapshot(...storeNames) {
+    const state = snapshot(this, ...storeNames)
+    if(this[LAST_SNAPSHOT]) {
+      assign(this[LAST_SNAPSHOT], state)
+    }
+    else {
+      this[LAST_SNAPSHOT] = state
+    }
     return state
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -473,6 +473,12 @@ const tests = {
     assert(JSON.parse(snapshot).MyStore.name === 'bear', 'the snapshot is not affected by action')
   },
 
+  'specifying stores to snapshot'() {
+    const snapshot = alt.takeSnapshot('MyStore', 'AltSecondStore')
+    assert.deepEqual(Object.keys(JSON.parse(snapshot)), ['MyStore', 'AltSecondStore'], 'the snapshot includes specified stores')
+    assert.isFalse(Object.keys(JSON.parse(snapshot)).includes('LifeCycleStore'), 'the snapshot does not include unspecified stores')
+  },
+
   'serializing/deserializing snapshot/bootstrap data'(){
     myActions.updateAnotherVal(11)
     const snapshot = alt.takeSnapshot()


### PR DESCRIPTION
- This enables snapshotting a subset of the app data
- `takeSnapshot` returns stringified JSON containing just the subset of data specified. The new snapshot is merged with the `LAST_SNAPSHOT` data to ensure that the last snapshot of the stores not specified in the subset is not lost. This also means that rollbacks will just work.
- Resolves Issue #54