### PR TITLE
Update eslint and fix linting errors

### DIFF
--- a/dist/alt-browser-with-addons.js
+++ b/dist/alt-browser-with-addons.js
@@ -1197,7 +1197,9 @@ var StoreMixinListeners = {
         _this8.bindAction(symbol, listener);
       }
     });
-  } };
+  }
+
+};
 
 var StoreMixinEssentials = {
   waitFor: function waitFor(sources) {

--- a/dist/alt-browser.js
+++ b/dist/alt-browser.js
@@ -945,7 +945,9 @@ var StoreMixinListeners = {
         _this8.bindAction(symbol, listener);
       }
     });
-  } };
+  }
+
+};
 
 var StoreMixinEssentials = {
   waitFor: function waitFor(sources) {

--- a/dist/alt-with-runtime.js
+++ b/dist/alt-with-runtime.js
@@ -200,7 +200,9 @@ var StoreMixinListeners = {
         _this8.bindAction(symbol, listener);
       }
     });
-  } };
+  }
+
+};
 
 var StoreMixinEssentials = {
   waitFor: function waitFor(sources) {

--- a/dist/alt.js
+++ b/dist/alt.js
@@ -214,7 +214,9 @@ var StoreMixinListeners = {
         _this8.bindAction(symbol, listener);
       }
     });
-  } };
+  }
+
+};
 
 var StoreMixinEssentials = {
   waitFor: function waitFor(sources) {

--- a/package.json
+++ b/package.json
@@ -11,12 +11,11 @@
   },
   "devDependencies": {
     "babel": "^4.7.13",
-    "babel-eslint": "^1.0.14",
     "babelify": "^5.0.4",
     "browserify": "^9.0.3",
     "chai": "^2.1.0",
     "coveralls": "^2.11.2",
-    "eslint": "^0.16.1",
+    "eslint": "^0.17.1",
     "iso": "^4.0.2",
     "istanbul": "^0.3.5",
     "mocha": "^2.1.0",
@@ -50,9 +49,12 @@
     "unidirectional"
   ],
   "eslintConfig": {
-    "parser": "babel-eslint",
     "env": {
-      "node": true
+      "node": true,
+      "es6": true
+    },
+    "ecmaFeatures": {
+      "modules": true
     },
     "rules": {
       "brace-style": [

--- a/src/alt.js
+++ b/src/alt.js
@@ -185,7 +185,7 @@ const StoreMixinListeners = {
         this.bindAction(symbol, listener)
       }
     })
-  },
+  }
 
 }
 

--- a/utils/AltTestingUtils.js
+++ b/utils/AltTestingUtils.js
@@ -2,11 +2,13 @@ var assign = require('object-assign')
 var noop = function () { }
 
 // babelHelpers
+/*eslint-disable */
 /* istanbul ignore next */
 var _get = function get(object, property, receiver) { var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc && desc.writable) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };
 
 /* istanbul ignore next */
 var _inherits = function (subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; };
+/*eslint-enable */
 
 var AltTestingUtils = {
   createStoreSpy: function (alt) {


### PR DESCRIPTION
- Update to latest version of eslint with much better es6 support. We no longer will need `babel-eslint`
- Fix all linting errors