### PR TITLE
Add store instance properties

### DIFF
--- a/dist/alt-browser-with-addons.js
+++ b/dist/alt-browser-with-addons.js
@@ -1004,6 +1004,7 @@ var assign = _interopRequire(require("object-assign"));
 var ACTION_HANDLER = Symbol("action creator handler");
 var ACTION_KEY = Symbol("holds the actions uid symbol for listening");
 var ACTION_UID = Symbol("the actions uid name");
+var ALL_LISTENERS = Symbol("name of listeners");
 var EE = Symbol("event emitter instance");
 var INIT_SNAPSHOT = Symbol("init snapshot storage");
 var LAST_SNAPSHOT = Symbol("last snapshot storage");
@@ -1047,7 +1048,7 @@ var getInternalMethods = function (obj, excluded) {
 };
 
 var AltStore = (function () {
-  function AltStore(dispatcher, model, state) {
+  function AltStore(dispatcher, model, state, StoreModel) {
     var _this8 = this;
 
     _classCallCheck(this, AltStore);
@@ -1055,6 +1056,9 @@ var AltStore = (function () {
     this[EE] = new EventEmitter();
     this[LIFECYCLE] = {};
     this[STATE_CONTAINER] = state || model;
+
+    this.listenerNames = model[ALL_LISTENERS];
+    this.StoreModel = typeof StoreModel === "function" ? StoreModel : assign({}, StoreModel);
 
     assign(this[LIFECYCLE], model[LIFECYCLE]);
     assign(this, model[PUBLIC_METHODS]);
@@ -1145,11 +1149,9 @@ var StoreMixinListeners = {
     }
 
     // You can pass in the constant or the function itself
-    if (symbol[ACTION_KEY]) {
-      this[LISTENERS][symbol[ACTION_KEY]] = handler.bind(this);
-    } else {
-      this[LISTENERS][symbol] = handler.bind(this);
-    }
+    var key = symbol[ACTION_KEY] ? symbol[ACTION_KEY] : symbol;
+    this[LISTENERS][key] = handler.bind(this);
+    this[ALL_LISTENERS].push(Symbol.keyFor(key));
   },
 
   bindActions: function bindActions(actions) {
@@ -1291,6 +1293,7 @@ var createStoreFromObject = function (alt, StoreModel, key, saveStore) {
   var storeInstance = undefined;
 
   var StoreProto = {};
+  StoreProto[ALL_LISTENERS] = [];
   StoreProto[LIFECYCLE] = {};
   StoreProto[LISTENERS] = {};
 
@@ -1325,7 +1328,7 @@ var createStoreFromObject = function (alt, StoreModel, key, saveStore) {
   }
 
   // create the instance and assign the public methods to the instance
-  storeInstance = assign(new AltStore(alt.dispatcher, StoreProto, StoreProto.state), StoreProto.publicMethods);
+  storeInstance = assign(new AltStore(alt.dispatcher, StoreProto, StoreProto.state, StoreModel), StoreProto.publicMethods);
 
   /* istanbul ignore else */
   if (saveStore) {
@@ -1408,13 +1411,14 @@ var Alt = (function () {
           }
         });
 
+        Store.prototype[ALL_LISTENERS] = [];
         Store.prototype[LIFECYCLE] = {};
         Store.prototype[LISTENERS] = {};
         Store.prototype[PUBLIC_METHODS] = {};
 
         var store = new Store(this);
 
-        storeInstance = assign(new AltStore(this.dispatcher, store), getInternalMethods(StoreModel, builtIns));
+        storeInstance = assign(new AltStore(this.dispatcher, store, null, StoreModel), getInternalMethods(StoreModel, builtIns));
 
         if (saveStore) {
           this.stores[key] = storeInstance;

--- a/dist/alt-browser-with-addons.js
+++ b/dist/alt-browser-with-addons.js
@@ -1057,8 +1057,11 @@ var AltStore = (function () {
     this[LIFECYCLE] = {};
     this[STATE_CONTAINER] = state || model;
 
-    this.listenerNames = model[ALL_LISTENERS];
-    this.StoreModel = typeof StoreModel === "function" ? StoreModel : assign({}, StoreModel);
+    this.boundListeners = model[ALL_LISTENERS];
+    this.StoreModel = StoreModel;
+    if (typeof this.StoreModel === "object") {
+      this.StoreModel.state = assign({}, StoreModel.state);
+    }
 
     assign(this[LIFECYCLE], model[LIFECYCLE]);
     assign(this, model[PUBLIC_METHODS]);

--- a/dist/alt-browser.js
+++ b/dist/alt-browser.js
@@ -752,6 +752,7 @@ var assign = _interopRequire(require("object-assign"));
 var ACTION_HANDLER = Symbol("action creator handler");
 var ACTION_KEY = Symbol("holds the actions uid symbol for listening");
 var ACTION_UID = Symbol("the actions uid name");
+var ALL_LISTENERS = Symbol("name of listeners");
 var EE = Symbol("event emitter instance");
 var INIT_SNAPSHOT = Symbol("init snapshot storage");
 var LAST_SNAPSHOT = Symbol("last snapshot storage");
@@ -795,7 +796,7 @@ var getInternalMethods = function (obj, excluded) {
 };
 
 var AltStore = (function () {
-  function AltStore(dispatcher, model, state) {
+  function AltStore(dispatcher, model, state, StoreModel) {
     var _this8 = this;
 
     _classCallCheck(this, AltStore);
@@ -803,6 +804,9 @@ var AltStore = (function () {
     this[EE] = new EventEmitter();
     this[LIFECYCLE] = {};
     this[STATE_CONTAINER] = state || model;
+
+    this.listenerNames = model[ALL_LISTENERS];
+    this.StoreModel = typeof StoreModel === "function" ? StoreModel : assign({}, StoreModel);
 
     assign(this[LIFECYCLE], model[LIFECYCLE]);
     assign(this, model[PUBLIC_METHODS]);
@@ -893,11 +897,9 @@ var StoreMixinListeners = {
     }
 
     // You can pass in the constant or the function itself
-    if (symbol[ACTION_KEY]) {
-      this[LISTENERS][symbol[ACTION_KEY]] = handler.bind(this);
-    } else {
-      this[LISTENERS][symbol] = handler.bind(this);
-    }
+    var key = symbol[ACTION_KEY] ? symbol[ACTION_KEY] : symbol;
+    this[LISTENERS][key] = handler.bind(this);
+    this[ALL_LISTENERS].push(Symbol.keyFor(key));
   },
 
   bindActions: function bindActions(actions) {
@@ -1039,6 +1041,7 @@ var createStoreFromObject = function (alt, StoreModel, key, saveStore) {
   var storeInstance = undefined;
 
   var StoreProto = {};
+  StoreProto[ALL_LISTENERS] = [];
   StoreProto[LIFECYCLE] = {};
   StoreProto[LISTENERS] = {};
 
@@ -1073,7 +1076,7 @@ var createStoreFromObject = function (alt, StoreModel, key, saveStore) {
   }
 
   // create the instance and assign the public methods to the instance
-  storeInstance = assign(new AltStore(alt.dispatcher, StoreProto, StoreProto.state), StoreProto.publicMethods);
+  storeInstance = assign(new AltStore(alt.dispatcher, StoreProto, StoreProto.state, StoreModel), StoreProto.publicMethods);
 
   /* istanbul ignore else */
   if (saveStore) {
@@ -1156,13 +1159,14 @@ var Alt = (function () {
           }
         });
 
+        Store.prototype[ALL_LISTENERS] = [];
         Store.prototype[LIFECYCLE] = {};
         Store.prototype[LISTENERS] = {};
         Store.prototype[PUBLIC_METHODS] = {};
 
         var store = new Store(this);
 
-        storeInstance = assign(new AltStore(this.dispatcher, store), getInternalMethods(StoreModel, builtIns));
+        storeInstance = assign(new AltStore(this.dispatcher, store, null, StoreModel), getInternalMethods(StoreModel, builtIns));
 
         if (saveStore) {
           this.stores[key] = storeInstance;

--- a/dist/alt-browser.js
+++ b/dist/alt-browser.js
@@ -805,8 +805,11 @@ var AltStore = (function () {
     this[LIFECYCLE] = {};
     this[STATE_CONTAINER] = state || model;
 
-    this.listenerNames = model[ALL_LISTENERS];
-    this.StoreModel = typeof StoreModel === "function" ? StoreModel : assign({}, StoreModel);
+    this.boundListeners = model[ALL_LISTENERS];
+    this.StoreModel = StoreModel;
+    if (typeof this.StoreModel === "object") {
+      this.StoreModel.state = assign({}, StoreModel.state);
+    }
 
     assign(this[LIFECYCLE], model[LIFECYCLE]);
     assign(this, model[PUBLIC_METHODS]);

--- a/dist/alt-with-runtime.js
+++ b/dist/alt-with-runtime.js
@@ -9,6 +9,7 @@ var assign = babelHelpers.interopRequire(require("object-assign"));
 var ACTION_HANDLER = Symbol("action creator handler");
 var ACTION_KEY = Symbol("holds the actions uid symbol for listening");
 var ACTION_UID = Symbol("the actions uid name");
+var ALL_LISTENERS = Symbol("name of listeners");
 var EE = Symbol("event emitter instance");
 var INIT_SNAPSHOT = Symbol("init snapshot storage");
 var LAST_SNAPSHOT = Symbol("last snapshot storage");
@@ -52,7 +53,7 @@ var getInternalMethods = function (obj, excluded) {
 };
 
 var AltStore = (function () {
-  function AltStore(dispatcher, model, state) {
+  function AltStore(dispatcher, model, state, StoreModel) {
     var _this8 = this;
 
     babelHelpers.classCallCheck(this, AltStore);
@@ -60,6 +61,9 @@ var AltStore = (function () {
     this[EE] = new EventEmitter();
     this[LIFECYCLE] = {};
     this[STATE_CONTAINER] = state || model;
+
+    this.listenerNames = model[ALL_LISTENERS];
+    this.StoreModel = typeof StoreModel === "function" ? StoreModel : assign({}, StoreModel);
 
     assign(this[LIFECYCLE], model[LIFECYCLE]);
     assign(this, model[PUBLIC_METHODS]);
@@ -148,11 +152,9 @@ var StoreMixinListeners = {
     }
 
     // You can pass in the constant or the function itself
-    if (symbol[ACTION_KEY]) {
-      this[LISTENERS][symbol[ACTION_KEY]] = handler.bind(this);
-    } else {
-      this[LISTENERS][symbol] = handler.bind(this);
-    }
+    var key = symbol[ACTION_KEY] ? symbol[ACTION_KEY] : symbol;
+    this[LISTENERS][key] = handler.bind(this);
+    this[ALL_LISTENERS].push(Symbol.keyFor(key));
   },
 
   bindActions: function bindActions(actions) {
@@ -294,6 +296,7 @@ var createStoreFromObject = function (alt, StoreModel, key, saveStore) {
   var storeInstance = undefined;
 
   var StoreProto = {};
+  StoreProto[ALL_LISTENERS] = [];
   StoreProto[LIFECYCLE] = {};
   StoreProto[LISTENERS] = {};
 
@@ -328,7 +331,7 @@ var createStoreFromObject = function (alt, StoreModel, key, saveStore) {
   }
 
   // create the instance and assign the public methods to the instance
-  storeInstance = assign(new AltStore(alt.dispatcher, StoreProto, StoreProto.state), StoreProto.publicMethods);
+  storeInstance = assign(new AltStore(alt.dispatcher, StoreProto, StoreProto.state, StoreModel), StoreProto.publicMethods);
 
   /* istanbul ignore else */
   if (saveStore) {
@@ -410,13 +413,14 @@ var Alt = (function () {
           }
         });
 
+        Store.prototype[ALL_LISTENERS] = [];
         Store.prototype[LIFECYCLE] = {};
         Store.prototype[LISTENERS] = {};
         Store.prototype[PUBLIC_METHODS] = {};
 
         var store = new Store(this);
 
-        storeInstance = assign(new AltStore(this.dispatcher, store), getInternalMethods(StoreModel, builtIns));
+        storeInstance = assign(new AltStore(this.dispatcher, store, null, StoreModel), getInternalMethods(StoreModel, builtIns));
 
         if (saveStore) {
           this.stores[key] = storeInstance;

--- a/dist/alt-with-runtime.js
+++ b/dist/alt-with-runtime.js
@@ -62,8 +62,11 @@ var AltStore = (function () {
     this[LIFECYCLE] = {};
     this[STATE_CONTAINER] = state || model;
 
-    this.listenerNames = model[ALL_LISTENERS];
-    this.StoreModel = typeof StoreModel === "function" ? StoreModel : assign({}, StoreModel);
+    this.boundListeners = model[ALL_LISTENERS];
+    this.StoreModel = StoreModel;
+    if (typeof this.StoreModel === "object") {
+      this.StoreModel.state = assign({}, StoreModel.state);
+    }
 
     assign(this[LIFECYCLE], model[LIFECYCLE]);
     assign(this, model[PUBLIC_METHODS]);

--- a/dist/alt.js
+++ b/dist/alt.js
@@ -21,6 +21,7 @@ var assign = _interopRequire(require("object-assign"));
 var ACTION_HANDLER = Symbol("action creator handler");
 var ACTION_KEY = Symbol("holds the actions uid symbol for listening");
 var ACTION_UID = Symbol("the actions uid name");
+var ALL_LISTENERS = Symbol("name of listeners");
 var EE = Symbol("event emitter instance");
 var INIT_SNAPSHOT = Symbol("init snapshot storage");
 var LAST_SNAPSHOT = Symbol("last snapshot storage");
@@ -64,7 +65,7 @@ var getInternalMethods = function (obj, excluded) {
 };
 
 var AltStore = (function () {
-  function AltStore(dispatcher, model, state) {
+  function AltStore(dispatcher, model, state, StoreModel) {
     var _this8 = this;
 
     _classCallCheck(this, AltStore);
@@ -72,6 +73,9 @@ var AltStore = (function () {
     this[EE] = new EventEmitter();
     this[LIFECYCLE] = {};
     this[STATE_CONTAINER] = state || model;
+
+    this.listenerNames = model[ALL_LISTENERS];
+    this.StoreModel = typeof StoreModel === "function" ? StoreModel : assign({}, StoreModel);
 
     assign(this[LIFECYCLE], model[LIFECYCLE]);
     assign(this, model[PUBLIC_METHODS]);
@@ -162,11 +166,9 @@ var StoreMixinListeners = {
     }
 
     // You can pass in the constant or the function itself
-    if (symbol[ACTION_KEY]) {
-      this[LISTENERS][symbol[ACTION_KEY]] = handler.bind(this);
-    } else {
-      this[LISTENERS][symbol] = handler.bind(this);
-    }
+    var key = symbol[ACTION_KEY] ? symbol[ACTION_KEY] : symbol;
+    this[LISTENERS][key] = handler.bind(this);
+    this[ALL_LISTENERS].push(Symbol.keyFor(key));
   },
 
   bindActions: function bindActions(actions) {
@@ -308,6 +310,7 @@ var createStoreFromObject = function (alt, StoreModel, key, saveStore) {
   var storeInstance = undefined;
 
   var StoreProto = {};
+  StoreProto[ALL_LISTENERS] = [];
   StoreProto[LIFECYCLE] = {};
   StoreProto[LISTENERS] = {};
 
@@ -342,7 +345,7 @@ var createStoreFromObject = function (alt, StoreModel, key, saveStore) {
   }
 
   // create the instance and assign the public methods to the instance
-  storeInstance = assign(new AltStore(alt.dispatcher, StoreProto, StoreProto.state), StoreProto.publicMethods);
+  storeInstance = assign(new AltStore(alt.dispatcher, StoreProto, StoreProto.state, StoreModel), StoreProto.publicMethods);
 
   /* istanbul ignore else */
   if (saveStore) {
@@ -425,13 +428,14 @@ var Alt = (function () {
           }
         });
 
+        Store.prototype[ALL_LISTENERS] = [];
         Store.prototype[LIFECYCLE] = {};
         Store.prototype[LISTENERS] = {};
         Store.prototype[PUBLIC_METHODS] = {};
 
         var store = new Store(this);
 
-        storeInstance = assign(new AltStore(this.dispatcher, store), getInternalMethods(StoreModel, builtIns));
+        storeInstance = assign(new AltStore(this.dispatcher, store, null, StoreModel), getInternalMethods(StoreModel, builtIns));
 
         if (saveStore) {
           this.stores[key] = storeInstance;

--- a/dist/alt.js
+++ b/dist/alt.js
@@ -74,8 +74,11 @@ var AltStore = (function () {
     this[LIFECYCLE] = {};
     this[STATE_CONTAINER] = state || model;
 
-    this.listenerNames = model[ALL_LISTENERS];
-    this.StoreModel = typeof StoreModel === "function" ? StoreModel : assign({}, StoreModel);
+    this.boundListeners = model[ALL_LISTENERS];
+    this.StoreModel = StoreModel;
+    if (typeof this.StoreModel === "object") {
+      this.StoreModel.state = assign({}, StoreModel.state);
+    }
 
     assign(this[LIFECYCLE], model[LIFECYCLE]);
     assign(this, model[PUBLIC_METHODS]);

--- a/src/alt.js
+++ b/src/alt.js
@@ -8,6 +8,7 @@ import assign from 'object-assign'
 const ACTION_HANDLER = Symbol('action creator handler')
 const ACTION_KEY = Symbol('holds the actions uid symbol for listening')
 const ACTION_UID = Symbol('the actions uid name')
+const ALL_LISTENERS = Symbol('name of listeners')
 const EE = Symbol('event emitter instance')
 const INIT_SNAPSHOT = Symbol('init snapshot storage')
 const LAST_SNAPSHOT = Symbol('last snapshot storage')
@@ -51,10 +52,15 @@ const getInternalMethods = (obj, excluded) => {
 }
 
 class AltStore {
-  constructor(dispatcher, model, state) {
+  constructor(dispatcher, model, state, StoreModel) {
     this[EE] = new EventEmitter()
     this[LIFECYCLE] = {}
     this[STATE_CONTAINER] = state || model
+
+    this.listenerNames = model[ALL_LISTENERS]
+    this.StoreModel = typeof StoreModel === 'function'
+      ? StoreModel
+      : assign({}, StoreModel)
 
     assign(this[LIFECYCLE], model[LIFECYCLE])
     assign(this, model[PUBLIC_METHODS])
@@ -132,11 +138,9 @@ const StoreMixinListeners = {
     }
 
     // You can pass in the constant or the function itself
-    if (symbol[ACTION_KEY]) {
-      this[LISTENERS][symbol[ACTION_KEY]] = handler.bind(this)
-    } else {
-      this[LISTENERS][symbol] = handler.bind(this)
-    }
+    const key = symbol[ACTION_KEY] ? symbol[ACTION_KEY] : symbol
+    this[LISTENERS][key] = handler.bind(this)
+    this[ALL_LISTENERS].push(Symbol.keyFor(key))
   },
 
   bindActions(actions) {
@@ -273,6 +277,7 @@ const createStoreFromObject = (alt, StoreModel, key, saveStore) => {
   let storeInstance
 
   const StoreProto = {}
+  StoreProto[ALL_LISTENERS] = []
   StoreProto[LIFECYCLE] = {}
   StoreProto[LISTENERS] = {}
 
@@ -306,7 +311,7 @@ const createStoreFromObject = (alt, StoreModel, key, saveStore) => {
 
   // create the instance and assign the public methods to the instance
   storeInstance = assign(
-    new AltStore(alt.dispatcher, StoreProto, StoreProto.state),
+    new AltStore(alt.dispatcher, StoreProto, StoreProto.state, StoreModel),
     StoreProto.publicMethods
   )
 
@@ -378,6 +383,7 @@ class Alt {
       }
     })
 
+    Store.prototype[ALL_LISTENERS] = []
     Store.prototype[LIFECYCLE] = {}
     Store.prototype[LISTENERS] = {}
     Store.prototype[PUBLIC_METHODS] = {}
@@ -385,7 +391,7 @@ class Alt {
     const store = new Store(this)
 
     storeInstance = assign(
-      new AltStore(this.dispatcher, store),
+      new AltStore(this.dispatcher, store, null, StoreModel),
       getInternalMethods(StoreModel, builtIns)
     )
 

--- a/src/alt.js
+++ b/src/alt.js
@@ -57,10 +57,11 @@ class AltStore {
     this[LIFECYCLE] = {}
     this[STATE_CONTAINER] = state || model
 
-    this.listenerNames = model[ALL_LISTENERS]
-    this.StoreModel = typeof StoreModel === 'function'
-      ? StoreModel
-      : assign({}, StoreModel)
+    this.boundListeners = model[ALL_LISTENERS]
+    this.StoreModel = StoreModel
+    if (typeof this.StoreModel === 'object') {
+      this.StoreModel.state = assign({}, StoreModel.state)
+    }
 
     assign(this[LIFECYCLE], model[LIFECYCLE])
     assign(this, model[PUBLIC_METHODS])

--- a/test/bound-listeners-test.js
+++ b/test/bound-listeners-test.js
@@ -1,0 +1,74 @@
+import Alt from '../dist/alt-with-runtime'
+import { assert } from 'chai'
+import Symbol from 'es-symbol'
+
+const alt = new Alt()
+
+const Actions = alt.generateActions('one', 'two', 'three')
+
+class NoActions {
+  constructor() {
+    this.bindActions(Actions)
+  }
+
+  foo() { }
+  bar() { }
+}
+
+class OneAction {
+  constructor() {
+    this.bindAction(Actions.ONE, this.one)
+  }
+
+  one() { }
+}
+
+class TwoAction {
+  constructor() {
+    this.bindListeners({
+      two: Actions.TWO
+    })
+  }
+
+  two() { }
+}
+
+class BindActions {
+  constructor() {
+    this.bindActions(Actions)
+  }
+
+  one() { }
+  two() { }
+}
+
+
+export default {
+  'Exporting listener names': {
+    'when no actions are listened on'() {
+      const myStore = alt.createStore(NoActions)
+      assert(myStore.boundListeners.length === 0, 'none are returned')
+    },
+
+    'when using bindAction'() {
+      const myStore = alt.createStore(OneAction)
+      assert(myStore.boundListeners.length === 1)
+      assert(myStore.boundListeners[0] === Symbol.keyFor(Actions.ONE))
+    },
+
+    'when using bindListeners'() {
+      const myStore = alt.createStore(TwoAction)
+      assert(myStore.boundListeners.length === 1)
+      assert(myStore.boundListeners[0] === Symbol.keyFor(Actions.TWO))
+    },
+
+    'when using bindActions'() {
+      const myStore = alt.createStore(BindActions)
+      assert(myStore.boundListeners.length === 2)
+      assert(
+        myStore.boundListeners.indexOf(Symbol.keyFor(Actions.ONE)) > -1 &&
+        myStore.boundListeners.indexOf(Symbol.keyFor(Actions.TWO)) > -1
+      )
+    },
+  }
+}

--- a/test/store-model-test.js
+++ b/test/store-model-test.js
@@ -1,0 +1,70 @@
+import Alt from '../dist/alt-with-runtime'
+import { assert } from 'chai'
+
+const alt = new Alt()
+const Actions = alt.generateActions('hello')
+
+function MyStoreModel() {
+  this.bindActions(Actions)
+
+  this.test = 2
+}
+MyStoreModel.prototype.onHello = function () { this.test = 1 }
+
+const MyStoreModelObj = {
+  displayName: 'MyStoreAsObject',
+
+  state: { test: 2 },
+
+  bindListeners: {
+    onHello: Actions.HELLO
+  },
+
+  onHello: function () {
+    this.state.test = 1
+  }
+}
+
+export default {
+  'Exposing the StoreModel': {
+    beforeEach() {
+      alt.recycle()
+    },
+
+    'as an object'() {
+      const MyStore = alt.createStore(MyStoreModelObj)
+
+      assert(MyStore.getState().test === 2, 'store state is initially set')
+
+      assert.isDefined(MyStore.StoreModel, 'store model is available')
+      assert.isObject(MyStore.StoreModel, 'store model is an object')
+
+      MyStore.StoreModel.state.test = 4
+
+      assert(MyStore.StoreModel.state.test === 4, 'I have changed the store model state')
+
+      assert(MyStore.getState().test === 2, 'but that does not affect our store state')
+
+      assert(MyStore.StoreModel === MyStoreModelObj, 'the store model is the same as the original object')
+
+      Actions.hello()
+
+      assert(MyStore.getState().test === 1, 'i can change state through actions')
+    },
+
+    'as a class'() {
+      const MyStore = alt.createStore(MyStoreModel, 'MyStore')
+
+      assert(MyStore.getState().test === 2, 'store state is initially set')
+
+      assert.isDefined(MyStore.StoreModel, 'store model is available')
+      assert.isFunction(MyStore.StoreModel, 'store model is a function')
+
+      assert(MyStore.StoreModel === MyStoreModel, 'the store model is the same as the original object')
+
+      Actions.hello()
+
+      assert(MyStore.getState().test === 1, 'i can change state through actions')
+    },
+  }
+}


### PR DESCRIPTION
This opens the door for a couple of things:

Having direct access to the store model constructor makes for nice and easy testing (no more double exports) and it also makes for better introspection.

Having the names of the subscribed listeners is good for introspection.

These are properties rather than functions because I see no reason to hide them and mutating them shouldn't have terrible consequences.