### PR TITLE
Setup tasks to build gh-pages site

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,2 +1,4 @@
-_site
 .sass-cache
+.bundle
+_site
+docs

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -2,3 +2,4 @@
 .bundle
 _site
 docs
+guide

--- a/web/Gemfile
+++ b/web/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+ruby '2.1.2'
+
+gem 'rake'
+gem 'jekyll'
+gem 'sass'

--- a/web/Gemfile.lock
+++ b/web/Gemfile.lock
@@ -1,0 +1,73 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    blankslate (2.1.2.4)
+    celluloid (0.16.0)
+      timers (~> 4.0.0)
+    classifier-reborn (2.0.3)
+      fast-stemmer (~> 1.0)
+    coffee-script (2.3.0)
+      coffee-script-source
+      execjs
+    coffee-script-source (1.9.1)
+    colorator (0.1)
+    execjs (2.4.0)
+    fast-stemmer (1.0.2)
+    ffi (1.9.8)
+    hitimes (1.2.2)
+    jekyll (2.5.3)
+      classifier-reborn (~> 2.0)
+      colorator (~> 0.1)
+      jekyll-coffeescript (~> 1.0)
+      jekyll-gist (~> 1.0)
+      jekyll-paginate (~> 1.0)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 1.1)
+      kramdown (~> 1.3)
+      liquid (~> 2.6.1)
+      mercenary (~> 0.3.3)
+      pygments.rb (~> 0.6.0)
+      redcarpet (~> 3.1)
+      safe_yaml (~> 1.0)
+      toml (~> 0.1.0)
+    jekyll-coffeescript (1.0.1)
+      coffee-script (~> 2.2)
+    jekyll-gist (1.2.1)
+    jekyll-paginate (1.1.0)
+    jekyll-sass-converter (1.3.0)
+      sass (~> 3.2)
+    jekyll-watch (1.2.1)
+      listen (~> 2.7)
+    kramdown (1.6.0)
+    liquid (2.6.2)
+    listen (2.9.0)
+      celluloid (>= 0.15.2)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9)
+    mercenary (0.3.5)
+    parslet (1.5.0)
+      blankslate (~> 2.0)
+    posix-spawn (0.3.10)
+    pygments.rb (0.6.2)
+      posix-spawn (~> 0.3.6)
+      yajl-ruby (~> 1.2.0)
+    rake (10.4.2)
+    rb-fsevent (0.9.4)
+    rb-inotify (0.9.5)
+      ffi (>= 0.5.0)
+    redcarpet (3.2.2)
+    safe_yaml (1.0.4)
+    sass (3.4.13)
+    timers (4.0.1)
+      hitimes
+    toml (0.1.2)
+      parslet (~> 1.5.0)
+    yajl-ruby (1.2.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jekyll
+  rake
+  sass

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,24 @@
+# Website
+
+This is the source of the [alt website](github.io/goatslacker/alt), which is generated using [Github Pages](https://pages.github.com/) and [Jekyll](http://jekyllrb.com/).
+
+The source utilizes the same `docs` folder as the rest of the project, but converts the links from their usable format on github, to work with the website.
+
+## Setup
+
+You must first install the Ruby dependencies specified in the `Gemfile` with [bundler](http://bundler.io/), `bundle install --path .bundle`
+
+## Development
+
+This project uses [Rake](https://github.com/ruby/rake) to run commands to build/deploy the Ruby based Jekyll site.
+
+To view all the Rake commands available in the `Rakefile` run `bundle exec rake -T`.
+
+- Generate the Jekyll website (gets written to `_site/`) with `bundle exec rake build`.
+- Watch for changes and serve at `localhost:4000` with `bundle exec rake watch` or just `bundle exec rake` (because it is the default task).
+
+## Deploying
+
+Changes on the website are made directly to the `master` branch like any other alt changes, but they will not be deployed to the site automatically. The maintainers will use the rake deploy task which will commit the latest site changes to the `gh-pages` branch, where github will handle propagating these so they are viewable online.
+
+

--- a/web/Rakefile
+++ b/web/Rakefile
@@ -15,6 +15,7 @@ GITHUB_USER = 'goatslacker'
 desc 'Build the site'
 task :build do
   clean_and_copy_docs
+  clean_and_copy_guide
   system 'jekyll build'
 end
 
@@ -22,6 +23,7 @@ end
 desc 'Serve and watch the site'
 task :watch do
   clean_and_copy_docs
+  clean_and_copy_guide
   system 'jekyll serve --watch'
 end
 
@@ -64,6 +66,12 @@ def clean_and_copy_docs
   system 'rm -rf docs/'
   system 'cp -r ../docs .'
   format_markdown_links('docs')
+end
+
+def clean_and_copy_guide
+  system 'rm -rf guide/'
+  system 'cp -r ../guide .'
+  format_markdown_links('guide')
 end
 
 def format_markdown_links(dir)

--- a/web/Rakefile
+++ b/web/Rakefile
@@ -1,0 +1,89 @@
+require 'rake'
+require 'jekyll'
+require 'tmpdir'
+require 'tempfile'
+require 'fileutils'
+
+# Set "rake watch" as default task
+task :default => :watch
+
+GITHUB_REPONAME = 'alt'
+GITHUB_BRANCH = 'gh-pages-test'
+GITHUB_USER = 'goatslacker'
+
+# rake build
+desc 'Build the site'
+task :build do
+  clean_and_copy_docs
+  system 'jekyll build'
+end
+
+# rake watch
+desc 'Serve and watch the site'
+task :watch do
+  clean_and_copy_docs
+  system 'jekyll serve --watch'
+end
+
+
+# rake deploy
+# rake deploy['commit message']
+desc "Generate and deploy blog to #{GITHUB_BRANCH}"
+task :deploy, [:commit_message] => [:build] do |t, args|
+  commit_message = args[:commit_message] || `git log -1 --pretty=%B`
+  commit_message = commit_message.gsub('"', "'")
+  sha = `git log`.match(/[a-z0-9]{40}/)[0]
+
+  Dir.mktmpdir do |tmp|
+    clean_and_copy_docs
+    pwd = Dir.pwd
+    Dir.chdir tmp
+
+    # setup repo in tmp dir
+    system 'git init'
+    system "git remote add origin git@github.com:#{GITHUB_USER}/#{GITHUB_REPONAME}.git"
+    system "git pull origin #{GITHUB_BRANCH}"
+
+    # ensure that previously generated files that are now deleted do not remain
+    rm_rf Dir.glob("#{tmp}/*")
+    # copy latest production site generation
+    cp_r "#{pwd}/_site/.", tmp
+    # prevents github from trying to parse our generated content
+    system 'touch .nojekyll'
+
+    # commit and push
+    system 'git add .'
+    system "git commit -m \"#{sha}: #{commit_message}\""
+    system "git push origin master:refs/heads/#{GITHUB_BRANCH}"
+  end
+end
+
+private
+
+def clean_and_copy_docs
+  system 'rm -rf docs/'
+  system 'cp -r ../docs .'
+  format_markdown_links('docs')
+end
+
+def format_markdown_links(dir)
+  Dir[dir + '/**/*.md'].each do |file|
+    temp_file = Tempfile.new('tmp')
+    begin
+      File.open(file, 'r') do |file|
+        file.each_line do |line|
+          line.scan(/(?<all>(?<name>\[.+?\])\((?<link>.+?).md(?<hash>#.+?)?\))/).each do |all, name, link, hash|
+            line.gsub!(all, "#{name}(/#{dir}/#{link}#{hash})")
+          end
+
+          temp_file.puts line
+        end
+      end
+      temp_file.close
+      FileUtils.mv(temp_file.path, file)
+    ensure
+      temp_file.close
+      temp_file.unlink
+    end
+  end
+end

--- a/web/Rakefile
+++ b/web/Rakefile
@@ -8,7 +8,7 @@ require 'fileutils'
 task :default => :watch
 
 GITHUB_REPONAME = 'alt'
-GITHUB_BRANCH = 'gh-pages-test'
+GITHUB_BRANCH = 'gh-pages'
 GITHUB_USER = 'goatslacker'
 
 # rake build

--- a/web/_config.yml
+++ b/web/_config.yml
@@ -52,3 +52,13 @@ markdown: kramdown
 
 kramdown:
   input: GFM
+
+exclude:
+  - Rakefile
+  - Gemfile
+  - Gemfile.lock
+  - README.md
+  - .npmignore
+  - .gitignore
+  - .travis.yml
+  - .editorconfig


### PR DESCRIPTION
- Enables use of docs/, guides/ folders from master branch. Just
  converts the links into the format the web expects.
- Website work is still done on master branch. Rake task is used to
  deploy latest changes to gh-pages branch.
- Sets up Jekyll such that development can be done locally to ensure
  that the site looks correct before deploying to gh-pages.
- Once this is merged in, we just need to run the deploy task and we will have our gh-pages branch set up and ready to go!