### PR TITLE
Allow custom dispatcher to be specified

### DIFF
--- a/dist/alt-browser-with-addons.js
+++ b/dist/alt-browser-with-addons.js
@@ -1,6 +1,5 @@
 (function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.Alt = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 "use strict";
-
 /**
  * This mixin lets you setup your listeners. It is similar to Fluxible's mixin.
  *
@@ -80,7 +79,6 @@ module.exports = FluxyMixin;
 
 },{"./Subscribe":4}],2:[function(require,module,exports){
 "use strict";
-
 var Subscribe = require("./Subscribe");
 
 var ListenerMixin = {
@@ -111,7 +109,6 @@ module.exports = ListenerMixin;
 
 },{"./Subscribe":4}],3:[function(require,module,exports){
 "use strict";
-
 /**
  * This mixin automatically sets the state for you based on the key you provide
  *
@@ -193,7 +190,6 @@ module.exports = ReactStateMagicMixin;
 
 },{"./Subscribe":4}],4:[function(require,module,exports){
 "use strict";
-
 var Symbol = require("es-symbol");
 var MIXIN_REGISTRY = Symbol("alt store listeners");
 
@@ -1355,9 +1351,11 @@ var createStoreFromObject = function (alt, StoreModel, key, saveStore) {
 
 var Alt = (function () {
   function Alt() {
+    var config = arguments[0] === undefined ? {} : arguments[0];
+
     _classCallCheck(this, Alt);
 
-    this.dispatcher = new Dispatcher();
+    this.dispatcher = config.dispatcher || new Dispatcher();
     this.actions = {};
     this.stores = {};
     this[LAST_SNAPSHOT] = this[INIT_SNAPSHOT] = "{}";
@@ -1449,9 +1447,7 @@ var Alt = (function () {
         }
 
         return this.createActions(function () {
-          var _ref;
-
-          (_ref = this).generateActions.apply(_ref, actionNames);
+          this.generateActions.apply(this, actionNames);
         });
       }
     },
@@ -1612,7 +1608,6 @@ module.exports = Alt;
 
 },{"es-symbol":5,"eventemitter3":6,"flux":7,"object-assign":10}],13:[function(require,module,exports){
 "use strict";
-
 /**
  * ActionListeners(alt: AltInstance): ActionListenersInstance
  *
@@ -1675,7 +1670,6 @@ ActionListeners.prototype.removeAllActionListeners = function () {
 
 },{"es-symbol":5}],14:[function(require,module,exports){
 "use strict";
-
 /**
  * DispatcherRecorder(alt: AltInstance): DispatcherInstance
  *
@@ -1811,7 +1805,6 @@ DispatcherRecorder.prototype.loadEvents = function (events) {
 
 },{"es-symbol":5}],15:[function(require,module,exports){
 "use strict";
-
 /**
  * makeFinalStore(alt: AltInstance): AltStore
  *

--- a/dist/alt-browser.js
+++ b/dist/alt-browser.js
@@ -1099,9 +1099,11 @@ var createStoreFromObject = function (alt, StoreModel, key, saveStore) {
 
 var Alt = (function () {
   function Alt() {
+    var config = arguments[0] === undefined ? {} : arguments[0];
+
     _classCallCheck(this, Alt);
 
-    this.dispatcher = new Dispatcher();
+    this.dispatcher = config.dispatcher || new Dispatcher();
     this.actions = {};
     this.stores = {};
     this[LAST_SNAPSHOT] = this[INIT_SNAPSHOT] = "{}";
@@ -1193,9 +1195,7 @@ var Alt = (function () {
         }
 
         return this.createActions(function () {
-          var _ref;
-
-          (_ref = this).generateActions.apply(_ref, actionNames);
+          this.generateActions.apply(this, actionNames);
         });
       }
     },

--- a/dist/alt-with-runtime.js
+++ b/dist/alt-with-runtime.js
@@ -354,9 +354,10 @@ var createStoreFromObject = function (alt, StoreModel, key, saveStore) {
 
 var Alt = (function () {
   function Alt() {
+    var config = arguments[0] === undefined ? {} : arguments[0];
     babelHelpers.classCallCheck(this, Alt);
 
-    this.dispatcher = new Dispatcher();
+    this.dispatcher = config.dispatcher || new Dispatcher();
     this.actions = {};
     this.stores = {};
     this[LAST_SNAPSHOT] = this[INIT_SNAPSHOT] = "{}";

--- a/dist/alt.js
+++ b/dist/alt.js
@@ -368,9 +368,11 @@ var createStoreFromObject = function (alt, StoreModel, key, saveStore) {
 
 var Alt = (function () {
   function Alt() {
+    var config = arguments[0] === undefined ? {} : arguments[0];
+
     _classCallCheck(this, Alt);
 
-    this.dispatcher = new Dispatcher();
+    this.dispatcher = config.dispatcher || new Dispatcher();
     this.actions = {};
     this.stores = {};
     this[LAST_SNAPSHOT] = this[INIT_SNAPSHOT] = "{}";

--- a/docs/altInstances.md
+++ b/docs/altInstances.md
@@ -13,7 +13,7 @@ Using instances of alt is fairly straightforward.
 
 ```js
 class MyAlt extends Alt {
-  constructor(config={}) {
+  constructor(config = {}) {
     super(config);
 
     this.addActions('myActions', ActionCreators);
@@ -33,7 +33,7 @@ var flux = new MyAlt();
 The alt constructor takes an optional configuration object. This is where you can configure your alt instance.
 
 ```js
-var flux = new MyAlt({
+var flux = new Alt({
   dispatcher: new MyDispatcher()
 });
 ```
@@ -41,7 +41,26 @@ var flux = new MyAlt({
 
 The following properties can be defined on the config object:
 
-- *dispatcher*: By default alt uses Facebook's Flux [dispatcher](https://github.com/facebook/flux/blob/master/src/Dispatcher.js), but you can provide your own dispatcher implementation for alt to use. Your dispatcher must have a similar interface to the Facebook dispatcher including, `waitFor`, `dispatchToken`, `register`, and `dispatch`.
+- *dispatcher*: By default alt uses Facebook's Flux [dispatcher](https://github.com/facebook/flux/blob/master/src/Dispatcher.js), but you can provide your own dispatcher implementation for alt to use. Your dispatcher must have a similar interface to the Facebook dispatcher including, `waitFor`, `register`, and `dispatch`.
+
+One easy way to provide your own dispatcher is to extend the Facebook dispatcher. The following example shows a dispatcher that extends Facebook's dispatcher, but modifies it such that all dispatched payloads are logged to the console and `register` has a custom implementation.
+
+```js
+class MyDispatcher extends Dispatcher {
+  constructor() {
+    super();
+  }
+
+  dispatch(payload) {
+    console.log(payload);
+    super.dispatch(payload);
+  }
+
+  register(callback) {
+    // custom register implementation
+  }
+}
+```
 
 ## AltClass#addActions
 

--- a/docs/altInstances.md
+++ b/docs/altInstances.md
@@ -13,8 +13,8 @@ Using instances of alt is fairly straightforward.
 
 ```js
 class MyAlt extends Alt {
-  constructor() {
-    super();
+  constructor(config={}) {
+    super(config);
 
     this.addActions('myActions', ActionCreators);
     this.addStore('storeName', Store);
@@ -25,6 +25,23 @@ var flux = new MyAlt();
 ```
 
 # AltClass
+
+## AltClass#constructor
+
+> constructor(config: object) : Alt
+
+The alt constructor takes an optional configuration object. This is where you can configure your alt instance.
+
+```js
+var flux = new MyAlt({
+  dispatcher: new MyDispatcher()
+});
+```
+### Config Object
+
+The following properties can be defined on the config object:
+
+- *dispatcher*: By default alt uses Facebook's Flux [dispatcher](https://github.com/facebook/flux/blob/master/src/Dispatcher.js), but you can provide your own dispatcher implementation for alt to use. Your dispatcher must have a similar interface to the Facebook dispatcher including, `waitFor`, `dispatchToken`, `register`, and `dispatch`.
 
 ## AltClass#addActions
 

--- a/src/alt.js
+++ b/src/alt.js
@@ -333,8 +333,8 @@ const createStoreFromObject = (alt, StoreModel, key, saveStore) => {
 }
 
 class Alt {
-  constructor() {
-    this.dispatcher = new Dispatcher()
+  constructor(config = {}) {
+    this.dispatcher = config.dispatcher || new Dispatcher()
     this.actions = {}
     this.stores = {}
     this[LAST_SNAPSHOT] = this[INIT_SNAPSHOT] = '{}'

--- a/test/alt-config-object.js
+++ b/test/alt-config-object.js
@@ -1,0 +1,23 @@
+import { assert } from 'chai'
+import Alt from '../dist/alt-with-runtime'
+
+class CustomDispatcher {
+  waitFor() {}
+  dispatchToken() {}
+  register() {}
+  dispatch() {}
+  extraMethod() {}
+}
+
+export default {
+  'custom dispatcher can be specified in alt config'() {
+    const alt = new Alt({
+      dispatcher: new CustomDispatcher()
+    })
+    const dispatcher = alt.dispatcher
+
+    // uses custom dispatcher
+    assert.equal(typeof dispatcher.extraMethod, 'function')
+    assert.equal(typeof dispatcher.dispatch, 'function')
+  }
+}


### PR DESCRIPTION
- alt constructor takes config object that enables user to override defaults, in this case the dispatcher
- If dispatcher has interface with waitFor, dispatchToken, register, and dispatch functions, then it is valid and can be used, otherwise the default FB dispatcher is used as fallback
- This PR sets up a clean infrastructure to allow users to override other alt defaults
- Solves Issue #106 