### PR TITLE
Allow serialize/deserialize functions to be specified by config

### DIFF
--- a/dist/alt-browser.js
+++ b/dist/alt-browser.js
@@ -1003,7 +1003,7 @@ var StoreMixinEssentials = {
 };
 
 var setAppState = function (instance, data, onStore) {
-  var obj = JSON.parse(data);
+  var obj = instance.deserialize(data);
   Object.keys(obj).forEach(function (key) {
     var store = instance.stores[key];
     if (store) {
@@ -1035,14 +1035,14 @@ var snapshot = function (instance) {
 
 var saveInitialSnapshot = function (instance, key) {
   var state = instance.stores[key][STATE_CONTAINER];
-  var initial = JSON.parse(instance[INIT_SNAPSHOT]);
+  var initial = instance.deserialize(instance[INIT_SNAPSHOT]);
   initial[key] = state;
-  instance[INIT_SNAPSHOT] = JSON.stringify(initial);
+  instance[INIT_SNAPSHOT] = instance.serialize(initial);
   instance[LAST_SNAPSHOT] = instance[INIT_SNAPSHOT];
 };
 
-var filterSnapshotOfStores = function (serializedSnapshot, storeNames) {
-  var stores = JSON.parse(serializedSnapshot);
+var filterSnapshotOfStores = function (instance, serializedSnapshot, storeNames) {
+  var stores = instance.deserialize(serializedSnapshot);
   var storesToReset = storeNames.reduce(function (obj, name) {
     if (!stores[name]) {
       throw new ReferenceError("" + name + " is not a valid store");
@@ -1050,7 +1050,7 @@ var filterSnapshotOfStores = function (serializedSnapshot, storeNames) {
     obj[name] = stores[name];
     return obj;
   }, {});
-  return JSON.stringify(storesToReset);
+  return instance.serialize(storesToReset);
 };
 
 var createStoreFromObject = function (alt, StoreModel, key, saveStore) {
@@ -1109,6 +1109,8 @@ var Alt = (function () {
 
     _classCallCheck(this, Alt);
 
+    this.serialize = config.serialize || JSON.stringify;
+    this.deserialize = config.deserialize || JSON.parse;
     this.dispatcher = config.dispatcher || new Dispatcher();
     this.actions = {};
     this.stores = {};
@@ -1283,8 +1285,8 @@ var Alt = (function () {
         }
 
         var state = snapshot.apply(undefined, [this].concat(storeNames));
-        this[LAST_SNAPSHOT] = JSON.stringify(assign(JSON.parse(this[LAST_SNAPSHOT]), state));
-        return JSON.stringify(state);
+        this[LAST_SNAPSHOT] = this.serialize(assign(this.deserialize(this[LAST_SNAPSHOT]), state));
+        return this.serialize(state);
       }
     },
     rollback: {
@@ -1303,7 +1305,7 @@ var Alt = (function () {
           storeNames[_key] = arguments[_key];
         }
 
-        var initialSnapshot = storeNames.length ? filterSnapshotOfStores(this[INIT_SNAPSHOT], storeNames) : this[INIT_SNAPSHOT];
+        var initialSnapshot = storeNames.length ? filterSnapshotOfStores(this, this[INIT_SNAPSHOT], storeNames) : this[INIT_SNAPSHOT];
 
         setAppState(this, initialSnapshot, function (store) {
           if (store[LIFECYCLE].init) {
@@ -1315,7 +1317,7 @@ var Alt = (function () {
     },
     flush: {
       value: function flush() {
-        var state = JSON.stringify(snapshot(this));
+        var state = this.serialize(snapshot(this));
         this.recycle();
         return state;
       }

--- a/dist/alt.js
+++ b/dist/alt.js
@@ -272,7 +272,7 @@ var StoreMixinEssentials = {
 };
 
 var setAppState = function (instance, data, onStore) {
-  var obj = JSON.parse(data);
+  var obj = instance.deserialize(data);
   Object.keys(obj).forEach(function (key) {
     var store = instance.stores[key];
     if (store) {
@@ -304,14 +304,14 @@ var snapshot = function (instance) {
 
 var saveInitialSnapshot = function (instance, key) {
   var state = instance.stores[key][STATE_CONTAINER];
-  var initial = JSON.parse(instance[INIT_SNAPSHOT]);
+  var initial = instance.deserialize(instance[INIT_SNAPSHOT]);
   initial[key] = state;
-  instance[INIT_SNAPSHOT] = JSON.stringify(initial);
+  instance[INIT_SNAPSHOT] = instance.serialize(initial);
   instance[LAST_SNAPSHOT] = instance[INIT_SNAPSHOT];
 };
 
-var filterSnapshotOfStores = function (serializedSnapshot, storeNames) {
-  var stores = JSON.parse(serializedSnapshot);
+var filterSnapshotOfStores = function (instance, serializedSnapshot, storeNames) {
+  var stores = instance.deserialize(serializedSnapshot);
   var storesToReset = storeNames.reduce(function (obj, name) {
     if (!stores[name]) {
       throw new ReferenceError("" + name + " is not a valid store");
@@ -319,7 +319,7 @@ var filterSnapshotOfStores = function (serializedSnapshot, storeNames) {
     obj[name] = stores[name];
     return obj;
   }, {});
-  return JSON.stringify(storesToReset);
+  return instance.serialize(storesToReset);
 };
 
 var createStoreFromObject = function (alt, StoreModel, key, saveStore) {
@@ -378,6 +378,8 @@ var Alt = (function () {
 
     _classCallCheck(this, Alt);
 
+    this.serialize = config.serialize || JSON.stringify;
+    this.deserialize = config.deserialize || JSON.parse;
     this.dispatcher = config.dispatcher || new Dispatcher();
     this.actions = {};
     this.stores = {};
@@ -552,8 +554,8 @@ var Alt = (function () {
         }
 
         var state = snapshot.apply(undefined, [this].concat(storeNames));
-        this[LAST_SNAPSHOT] = JSON.stringify(assign(JSON.parse(this[LAST_SNAPSHOT]), state));
-        return JSON.stringify(state);
+        this[LAST_SNAPSHOT] = this.serialize(assign(this.deserialize(this[LAST_SNAPSHOT]), state));
+        return this.serialize(state);
       }
     },
     rollback: {
@@ -572,7 +574,7 @@ var Alt = (function () {
           storeNames[_key] = arguments[_key];
         }
 
-        var initialSnapshot = storeNames.length ? filterSnapshotOfStores(this[INIT_SNAPSHOT], storeNames) : this[INIT_SNAPSHOT];
+        var initialSnapshot = storeNames.length ? filterSnapshotOfStores(this, this[INIT_SNAPSHOT], storeNames) : this[INIT_SNAPSHOT];
 
         setAppState(this, initialSnapshot, function (store) {
           if (store[LIFECYCLE].init) {
@@ -584,7 +586,7 @@ var Alt = (function () {
     },
     flush: {
       value: function flush() {
-        var state = JSON.stringify(snapshot(this));
+        var state = this.serialize(snapshot(this));
         this.recycle();
         return state;
       }

--- a/docs/altInstances.md
+++ b/docs/altInstances.md
@@ -41,7 +41,9 @@ var flux = new Alt({
 
 The following properties can be defined on the config object:
 
-- *dispatcher*: By default alt uses Facebook's Flux [dispatcher](https://github.com/facebook/flux/blob/master/src/Dispatcher.js), but you can provide your own dispatcher implementation for alt to use. Your dispatcher must have a similar interface to the Facebook dispatcher including, `waitFor`, `register`, and `dispatch`.
+#### dispatcher
+
+By default alt uses Facebook's Flux [dispatcher](https://github.com/facebook/flux/blob/master/src/Dispatcher.js), but you can provide your own dispatcher implementation for alt to use. Your dispatcher must have a similar interface to the Facebook dispatcher including, `waitFor`, `register`, and `dispatch`.
 
 One easy way to provide your own dispatcher is to extend the Facebook dispatcher. The following example shows a dispatcher that extends Facebook's dispatcher, but modifies it such that all dispatched payloads are logged to the console and `register` has a custom implementation.
 
@@ -61,6 +63,14 @@ class MyDispatcher extends Dispatcher {
   }
 }
 ```
+
+#### serialize
+
+This controls how store data is serialized in snapshots. By default alt uses `JSON.stringify`, but you can provide your own function to serialize data.
+
+#### deserialize
+
+This controls how store data is deserialized from snapshot/bootstrap data. By default alt uses `JSON.parse`, but you can provide your own function to deserialize data.
 
 ## AltClass#addActions
 

--- a/src/alt.js
+++ b/src/alt.js
@@ -249,7 +249,7 @@ const StoreMixinEssentials = {
 }
 
 const setAppState = (instance, data, onStore) => {
-  const obj = JSON.parse(data)
+  const obj = instance.deserialize(data)
   Object.keys(obj).forEach((key) => {
     const store = instance.stores[key]
     if (store) {
@@ -277,14 +277,14 @@ const snapshot = (instance, ...storeNames) => {
 
 const saveInitialSnapshot = (instance, key) => {
   const state = instance.stores[key][STATE_CONTAINER]
-  const initial = JSON.parse(instance[INIT_SNAPSHOT])
+  const initial = instance.deserialize(instance[INIT_SNAPSHOT])
   initial[key] = state
-  instance[INIT_SNAPSHOT] = JSON.stringify(initial)
+  instance[INIT_SNAPSHOT] = instance.serialize(initial)
   instance[LAST_SNAPSHOT] = instance[INIT_SNAPSHOT]
 }
 
-const filterSnapshotOfStores = (serializedSnapshot, storeNames) => {
-  const stores = JSON.parse(serializedSnapshot)
+const filterSnapshotOfStores = (instance, serializedSnapshot, storeNames) => {
+  const stores = instance.deserialize(serializedSnapshot)
   const storesToReset = storeNames.reduce((obj, name) => {
     if (!stores[name]) {
       throw new ReferenceError(`${name} is not a valid store`)
@@ -292,7 +292,7 @@ const filterSnapshotOfStores = (serializedSnapshot, storeNames) => {
     obj[name] = stores[name]
     return obj
   }, {})
-  return JSON.stringify(storesToReset)
+  return instance.serialize(storesToReset)
 }
 
 const createStoreFromObject = (alt, StoreModel, key, saveStore) => {
@@ -348,6 +348,8 @@ const createStoreFromObject = (alt, StoreModel, key, saveStore) => {
 
 class Alt {
   constructor(config = {}) {
+    this.serialize = config.serialize || JSON.stringify
+    this.deserialize = config.deserialize || JSON.parse
     this.dispatcher = config.dispatcher || new Dispatcher()
     this.actions = {}
     this.stores = {}
@@ -485,10 +487,10 @@ class Alt {
 
   takeSnapshot(...storeNames) {
     const state = snapshot(this, ...storeNames)
-    this[LAST_SNAPSHOT] = JSON.stringify(
-      assign(JSON.parse(this[LAST_SNAPSHOT]), state)
+    this[LAST_SNAPSHOT] = this.serialize(
+      assign(this.deserialize(this[LAST_SNAPSHOT]), state)
     )
-    return JSON.stringify(state)
+    return this.serialize(state)
   }
 
   rollback() {
@@ -502,7 +504,7 @@ class Alt {
 
   recycle(...storeNames) {
     const initialSnapshot = storeNames.length
-      ? filterSnapshotOfStores(this[INIT_SNAPSHOT], storeNames)
+      ? filterSnapshotOfStores(this, this[INIT_SNAPSHOT], storeNames)
       : this[INIT_SNAPSHOT]
 
     setAppState(this, initialSnapshot, (store) => {
@@ -514,7 +516,7 @@ class Alt {
   }
 
   flush() {
-    const state = JSON.stringify(snapshot(this))
+    const state = this.serialize(snapshot(this))
     this.recycle()
     return state
   }

--- a/test/alt-config-object.js
+++ b/test/alt-config-object.js
@@ -1,16 +1,32 @@
 import { assert } from 'chai'
 import Alt from '../dist/alt-with-runtime'
 
-class CustomDispatcher {
-  waitFor() {}
-  dispatchToken() {}
-  register() {}
-  dispatch() {}
-  extraMethod() {}
+class MyActions {
+  constructor() {
+    this.generateActions('changeNumber')
+  }
+}
+
+class MyStore {
+  constructor() {
+    this.number = 2
+    this.letter = 'a'
+  }
+
+  onChangeNumber() {
+    this.number *= 2
+  }
 }
 
 export default {
   'custom dispatcher can be specified in alt config'() {
+    class CustomDispatcher {
+      waitFor() {}
+      register() {}
+      dispatch() {}
+      extraMethod() {}
+    }
+
     const alt = new Alt({
       dispatcher: new CustomDispatcher()
     })
@@ -19,5 +35,33 @@ export default {
     // uses custom dispatcher
     assert.equal(typeof dispatcher.extraMethod, 'function')
     assert.equal(typeof dispatcher.dispatch, 'function')
+  },
+
+  'custom serialize/deserialize'() {
+    const CustomSerialize = (data) => {
+      return Object.keys(data).reduce((obj, key) => {
+        obj[key] = {wrapper: data[key]}
+        return obj
+      }, {})
+    }
+    const CustomDeserialize = (data) => {
+      return Object.keys(data).reduce((obj, key) => {
+        obj[key] = data[key].wrapper
+        return obj
+      }, {})
+    }
+
+    const alt = new Alt({
+      serialize: CustomSerialize,
+      deserialize: CustomDeserialize,
+    })
+    alt.addStore('MyStore', MyStore)
+    alt.addActions('MyActions', MyActions)
+    const snapshot = alt.takeSnapshot()
+    alt.getActions('MyActions').changeNumber()
+    alt.rollback()
+
+    assert.deepEqual(snapshot, {MyStore: {wrapper: {number: 2, letter: 'a'}}})
+    assert.deepEqual(alt.getStore('MyStore').getState(), {number: 2, letter: 'a'})
   }
 }


### PR DESCRIPTION
- By default alt uses JSON.stringify/JSON.parse. This change allows the config object to provide custom serialization/deserialization functions to be used in their place
- Resolves Issue #105 