### PR TITLE
Guide: change event suppress comment in store.md

### DIFF
--- a/guide/store.md
+++ b/guide/store.md
@@ -29,6 +29,7 @@ Stores automatically emit a change event when an action is dispatched through th
 ```js
 handleUpdateLocations(locations) {
   this.locations = locations;
+  // optionally return false to suppress the store change event
 }
 ```
 


### PR DESCRIPTION
Add a comment in the example action handler code about the optional ability to suppress the store change event after the action handler ends.