### PR TITLE
fix AltContainer using ES6 concise function

### DIFF
--- a/components/AltContainer.js
+++ b/components/AltContainer.js
@@ -104,7 +104,7 @@ var AltContainer = React.createClass({
     }
   },
 
-  addSubscription(store) {
+  addSubscription: function(store) {
     if (typeof store === 'object') {
       Subscribe.add(this, store, this.altSetState)
     }


### PR DESCRIPTION
Currently it throws 
```
AltContainer.js:107 Uncaught SyntaxError: Unexpected token (
```
when using AltContainer.

Another option would be to add 
```
  "browserify": {
    "transform": [
      "babelify"
    ]
  },
```
to package.json