### PR TITLE
Check context is not null

### DIFF
--- a/components/AltContainer.js
+++ b/components/AltContainer.js
@@ -116,8 +116,8 @@ var AltContainer = React.createClass({
 
   getProps: function () {
     return assign(
-      this.context.flux || this.props.flux
-        ? { flux: this.context.flux || this.props.flux }
+      (this.context && this.context.flux) || this.props.flux
+        ? { flux: (this.context && this.context.flux) || this.props.flux }
         : {},
       this.state
     )


### PR DESCRIPTION
I'm not sure why, maybe its React 0.13 related, but the AltContainer context was null on my application starting, which caused it to blow up when trying to call `this.context.flux`. This change adds a null check there.