### PR TITLE
Allow passing in args to store and actions constructors

### DIFF
--- a/dist/alt-browser-with-addons.js
+++ b/dist/alt-browser-with-addons.js
@@ -1072,7 +1072,7 @@ function NoopClass() {}
 var builtIns = Object.getOwnPropertyNames(NoopClass);
 var builtInProto = Object.getOwnPropertyNames(NoopClass.prototype);
 
-var getInternalMethods = function (obj, excluded) {
+function getInternalMethods(obj, excluded) {
   return Object.getOwnPropertyNames(obj).reduce(function (value, m) {
     if (excluded.indexOf(m) !== -1) {
       return value;
@@ -1081,7 +1081,7 @@ var getInternalMethods = function (obj, excluded) {
     value[m] = obj[m];
     return value;
   }, {});
-};
+}
 
 var AltStore = (function () {
   function AltStore(dispatcher, model, state, StoreModel) {
@@ -1320,7 +1320,7 @@ var StoreMixinEssentials = {
   }
 };
 
-var setAppState = function (instance, data, onStore) {
+function setAppState(instance, data, onStore) {
   var obj = instance.deserialize(data);
   Object.keys(obj).forEach(function (key) {
     var store = instance.stores[key];
@@ -1332,9 +1332,9 @@ var setAppState = function (instance, data, onStore) {
       onStore(store);
     }
   });
-};
+}
 
-var snapshot = function (instance) {
+function snapshot(instance) {
   for (var _len = arguments.length, storeNames = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
     storeNames[_key - 1] = arguments[_key];
   }
@@ -1349,17 +1349,17 @@ var snapshot = function (instance) {
     obj[key] = customSnapshot ? customSnapshot : store.getState();
     return obj;
   }, {});
-};
+}
 
-var saveInitialSnapshot = function (instance, key) {
+function saveInitialSnapshot(instance, key) {
   var state = instance.stores[key][STATE_CONTAINER];
   var initial = instance.deserialize(instance[INIT_SNAPSHOT]);
   initial[key] = state;
   instance[INIT_SNAPSHOT] = instance.serialize(initial);
   instance[LAST_SNAPSHOT] = instance[INIT_SNAPSHOT];
-};
+}
 
-var filterSnapshotOfStores = function (instance, serializedSnapshot, storeNames) {
+function filterSnapshotOfStores(instance, serializedSnapshot, storeNames) {
   var stores = instance.deserialize(serializedSnapshot);
   var storesToReset = storeNames.reduce(function (obj, name) {
     if (!stores[name]) {
@@ -1369,7 +1369,7 @@ var filterSnapshotOfStores = function (instance, serializedSnapshot, storeNames)
     return obj;
   }, {});
   return instance.serialize(storesToReset);
-};
+}
 
 function createStoreFromObject(alt, StoreModel, key) {
   var storeInstance = undefined;
@@ -1412,8 +1412,8 @@ function createStoreFromObject(alt, StoreModel, key) {
 }
 
 function createStoreFromClass(alt, StoreModel, key) {
-  for (var _len = arguments.length, args = Array(_len > 3 ? _len - 3 : 0), _key = 3; _key < _len; _key++) {
-    args[_key - 3] = arguments[_key];
+  for (var _len = arguments.length, argsForConstructor = Array(_len > 3 ? _len - 3 : 0), _key = 3; _key < _len; _key++) {
+    argsForConstructor[_key - 3] = arguments[_key];
   }
 
   var storeInstance = undefined;
@@ -1455,7 +1455,7 @@ function createStoreFromClass(alt, StoreModel, key) {
   Store.prototype[LISTENERS] = {};
   Store.prototype[PUBLIC_METHODS] = {};
 
-  var store = _applyConstructor(Store, args);
+  var store = _applyConstructor(Store, argsForConstructor);
 
   storeInstance = assign(new AltStore(alt.dispatcher, store, null, StoreModel), getInternalMethods(StoreModel, builtIns));
 
@@ -1558,8 +1558,8 @@ var Alt = (function () {
       value: function createActions(ActionsClass) {
         var _this8 = this;
 
-        for (var _len = arguments.length, args = Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
-          args[_key - 2] = arguments[_key];
+        for (var _len = arguments.length, argsForConstructor = Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
+          argsForConstructor[_key - 2] = arguments[_key];
         }
 
         var exportObj = arguments[1] === undefined ? {} : arguments[1];
@@ -1608,7 +1608,7 @@ var Alt = (function () {
               return ActionsGenerator;
             })(ActionsClass);
 
-            assign(actions, _applyConstructor(ActionsGenerator, args));
+            assign(actions, _applyConstructor(ActionsGenerator, argsForConstructor));
           })();
         } else {
           assign(actions, ActionsClass);
@@ -1681,7 +1681,13 @@ var Alt = (function () {
       // Instance type methods for injecting alt into your application as context
 
       value: function addActions(name, ActionsClass) {
-        this.actions[name] = Array.isArray(ActionsClass) ? this.generateActions.apply(this, ActionsClass) : this.createActions(ActionsClass);
+        var _ref;
+
+        for (var _len = arguments.length, args = Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
+          args[_key - 2] = arguments[_key];
+        }
+
+        this.actions[name] = Array.isArray(ActionsClass) ? this.generateActions.apply(this, ActionsClass) : (_ref = this).createActions.apply(_ref, [ActionsClass].concat(args));
       }
     },
     addStore: {

--- a/dist/alt-browser-with-addons.js
+++ b/dist/alt-browser-with-addons.js
@@ -989,6 +989,8 @@ module.exports = Alt;
 
 var _interopRequire = function (obj) { return obj && obj.__esModule ? obj["default"] : obj; };
 
+var _applyConstructor = function (Constructor, args) { var instance = Object.create(Constructor.prototype); var result = Constructor.apply(instance, args); return result != null && (typeof result == "object" || typeof result == "function") ? result : instance; };
+
 var _get = function get(object, property, receiver) { var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc && desc.writable) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };
 
 var _inherits = function (subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; };
@@ -1369,7 +1371,7 @@ var filterSnapshotOfStores = function (instance, serializedSnapshot, storeNames)
   return instance.serialize(storesToReset);
 };
 
-var createStoreFromObject = function (alt, StoreModel, key, saveStore) {
+function createStoreFromObject(alt, StoreModel, key) {
   var storeInstance = undefined;
 
   var StoreProto = {};
@@ -1406,14 +1408,59 @@ var createStoreFromObject = function (alt, StoreModel, key, saveStore) {
   // create the instance and assign the public methods to the instance
   storeInstance = assign(new AltStore(alt.dispatcher, StoreProto, StoreProto.state, StoreModel), StoreProto.publicMethods);
 
-  /* istanbul ignore else */
-  if (saveStore) {
-    alt.stores[key] = storeInstance;
-    saveInitialSnapshot(alt, key);
+  return storeInstance;
+}
+
+function createStoreFromClass(alt, StoreModel, key) {
+  for (var _len = arguments.length, args = Array(_len > 3 ? _len - 3 : 0), _key = 3; _key < _len; _key++) {
+    args[_key - 3] = arguments[_key];
   }
 
+  var storeInstance = undefined;
+
+  // Creating a class here so we don't overload the provided store's
+  // prototype with the mixin behaviour and I'm extending from StoreModel
+  // so we can inherit any extensions from the provided store.
+
+  var Store = (function (_StoreModel) {
+    function Store() {
+      for (var _len2 = arguments.length, args = Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
+        args[_key2] = arguments[_key2];
+      }
+
+      _classCallCheck(this, Store);
+
+      _get(Object.getPrototypeOf(Store.prototype), "constructor", this).apply(this, args);
+    }
+
+    _inherits(Store, _StoreModel);
+
+    return Store;
+  })(StoreModel);
+
+  assign(Store.prototype, StoreMixinListeners, StoreMixinEssentials, {
+    _storeName: key,
+    alt: alt,
+    dispatcher: alt.dispatcher,
+    getInstance: function getInstance() {
+      return storeInstance;
+    },
+    setState: function setState(nextState) {
+      doSetState(this, storeInstance, nextState);
+    }
+  });
+
+  Store.prototype[ALL_LISTENERS] = [];
+  Store.prototype[LIFECYCLE] = {};
+  Store.prototype[LISTENERS] = {};
+  Store.prototype[PUBLIC_METHODS] = {};
+
+  var store = _applyConstructor(Store, args);
+
+  storeInstance = assign(new AltStore(alt.dispatcher, store, null, StoreModel), getInternalMethods(StoreModel, builtIns));
+
   return storeInstance;
-};
+}
 
 var Alt = (function () {
   function Alt() {
@@ -1435,14 +1482,25 @@ var Alt = (function () {
         this.dispatcher.dispatch({ action: action, data: data });
       }
     },
+    createUnsavedStore: {
+      value: function createUnsavedStore(StoreModel) {
+        for (var _len = arguments.length, args = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+          args[_key - 1] = arguments[_key];
+        }
+
+        var key = StoreModel.displayName || "";
+        return typeof StoreModel === "object" ? createStoreFromObject(this, StoreModel, key) : createStoreFromClass.apply(undefined, [this, StoreModel, key].concat(args));
+      }
+    },
     createStore: {
       value: function createStore(StoreModel, iden) {
-        var saveStore = arguments[2] === undefined ? true : arguments[2];
+        for (var _len = arguments.length, args = Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
+          args[_key - 2] = arguments[_key];
+        }
 
-        var storeInstance = undefined;
         var key = iden || StoreModel.name || StoreModel.displayName || "";
 
-        if (saveStore && (this.stores[key] || !key)) {
+        if (this.stores[key] || !key) {
           if (this.stores[key]) {
             warn("A store named " + key + " already exists, double check your store " + "names or pass in your own custom identifier for each store");
           } else {
@@ -1452,51 +1510,10 @@ var Alt = (function () {
           key = uid(this.stores, key);
         }
 
-        if (typeof StoreModel === "object") {
-          return createStoreFromObject(this, StoreModel, key, saveStore);
-        }
+        var storeInstance = typeof StoreModel === "object" ? createStoreFromObject(this, StoreModel, key) : createStoreFromClass.apply(undefined, [this, StoreModel, key].concat(args));
 
-        // Creating a class here so we don't overload the provided store's
-        // prototype with the mixin behaviour and I'm extending from StoreModel
-        // so we can inherit any extensions from the provided store.
-
-        var Store = (function (_StoreModel) {
-          function Store(alt) {
-            _classCallCheck(this, Store);
-
-            _get(Object.getPrototypeOf(Store.prototype), "constructor", this).call(this, alt);
-          }
-
-          _inherits(Store, _StoreModel);
-
-          return Store;
-        })(StoreModel);
-
-        assign(Store.prototype, StoreMixinListeners, StoreMixinEssentials, {
-          _storeName: key,
-          alt: this,
-          dispatcher: this.dispatcher,
-          getInstance: function getInstance() {
-            return storeInstance;
-          },
-          setState: function setState(nextState) {
-            doSetState(this, storeInstance, nextState);
-          }
-        });
-
-        Store.prototype[ALL_LISTENERS] = [];
-        Store.prototype[LIFECYCLE] = {};
-        Store.prototype[LISTENERS] = {};
-        Store.prototype[PUBLIC_METHODS] = {};
-
-        var store = new Store(this);
-
-        storeInstance = assign(new AltStore(this.dispatcher, store, null, StoreModel), getInternalMethods(StoreModel, builtIns));
-
-        if (saveStore) {
-          this.stores[key] = storeInstance;
-          saveInitialSnapshot(this, key);
-        }
+        this.stores[key] = storeInstance;
+        saveInitialSnapshot(this, key);
 
         return storeInstance;
       }
@@ -1541,6 +1558,10 @@ var Alt = (function () {
       value: function createActions(ActionsClass) {
         var _this8 = this;
 
+        for (var _len = arguments.length, args = Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
+          args[_key - 2] = arguments[_key];
+        }
+
         var exportObj = arguments[1] === undefined ? {} : arguments[1];
 
         var actions = {};
@@ -1551,10 +1572,14 @@ var Alt = (function () {
             assign(actions, getInternalMethods(ActionsClass.prototype, builtInProto));
 
             var ActionsGenerator = (function (_ActionsClass) {
-              function ActionsGenerator(alt) {
+              function ActionsGenerator() {
+                for (var _len2 = arguments.length, args = Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
+                  args[_key2] = arguments[_key2];
+                }
+
                 _classCallCheck(this, ActionsGenerator);
 
-                _get(Object.getPrototypeOf(ActionsGenerator.prototype), "constructor", this).call(this, alt);
+                _get(Object.getPrototypeOf(ActionsGenerator.prototype), "constructor", this).apply(this, args);
               }
 
               _inherits(ActionsGenerator, _ActionsClass);
@@ -1562,15 +1587,15 @@ var Alt = (function () {
               _createClass(ActionsGenerator, {
                 generateActions: {
                   value: function generateActions() {
-                    for (var _len = arguments.length, actionNames = Array(_len), _key = 0; _key < _len; _key++) {
-                      actionNames[_key] = arguments[_key];
+                    for (var _len2 = arguments.length, actionNames = Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
+                      actionNames[_key2] = arguments[_key2];
                     }
 
                     actionNames.forEach(function (actionName) {
                       // This is a function so we can later bind this to ActionCreator
                       actions[actionName] = function (x) {
-                        for (var _len2 = arguments.length, a = Array(_len2 > 1 ? _len2 - 1 : 0), _key2 = 1; _key2 < _len2; _key2++) {
-                          a[_key2 - 1] = arguments[_key2];
+                        for (var _len3 = arguments.length, a = Array(_len3 > 1 ? _len3 - 1 : 0), _key3 = 1; _key3 < _len3; _key3++) {
+                          a[_key3 - 1] = arguments[_key3];
                         }
 
                         this.dispatch(a.length ? [x].concat(a) : x);
@@ -1583,7 +1608,7 @@ var Alt = (function () {
               return ActionsGenerator;
             })(ActionsClass);
 
-            assign(actions, new ActionsGenerator(_this8));
+            assign(actions, _applyConstructor(ActionsGenerator, args));
           })();
         } else {
           assign(actions, ActionsClass);
@@ -1660,8 +1685,14 @@ var Alt = (function () {
       }
     },
     addStore: {
-      value: function addStore(name, StoreModel, saveStore) {
-        this.createStore(StoreModel, name, saveStore);
+      value: function addStore(name, StoreModel) {
+        var _ref;
+
+        for (var _len = arguments.length, args = Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
+          args[_key - 2] = arguments[_key];
+        }
+
+        (_ref = this).createStore.apply(_ref, [StoreModel, name].concat(args));
       }
     },
     getActions: {
@@ -1921,7 +1952,7 @@ function FinalStore() {
 }
 
 function makeFinalStore(alt) {
-  return alt.createStore(FinalStore, "AltFinalStore", false);
+  return alt.createUnsavedStore(FinalStore);
 }
 
 },{}]},{},[11])(11)

--- a/dist/alt-browser.js
+++ b/dist/alt-browser.js
@@ -816,7 +816,7 @@ function NoopClass() {}
 var builtIns = Object.getOwnPropertyNames(NoopClass);
 var builtInProto = Object.getOwnPropertyNames(NoopClass.prototype);
 
-var getInternalMethods = function (obj, excluded) {
+function getInternalMethods(obj, excluded) {
   return Object.getOwnPropertyNames(obj).reduce(function (value, m) {
     if (excluded.indexOf(m) !== -1) {
       return value;
@@ -825,7 +825,7 @@ var getInternalMethods = function (obj, excluded) {
     value[m] = obj[m];
     return value;
   }, {});
-};
+}
 
 var AltStore = (function () {
   function AltStore(dispatcher, model, state, StoreModel) {
@@ -1064,7 +1064,7 @@ var StoreMixinEssentials = {
   }
 };
 
-var setAppState = function (instance, data, onStore) {
+function setAppState(instance, data, onStore) {
   var obj = instance.deserialize(data);
   Object.keys(obj).forEach(function (key) {
     var store = instance.stores[key];
@@ -1076,9 +1076,9 @@ var setAppState = function (instance, data, onStore) {
       onStore(store);
     }
   });
-};
+}
 
-var snapshot = function (instance) {
+function snapshot(instance) {
   for (var _len = arguments.length, storeNames = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
     storeNames[_key - 1] = arguments[_key];
   }
@@ -1093,17 +1093,17 @@ var snapshot = function (instance) {
     obj[key] = customSnapshot ? customSnapshot : store.getState();
     return obj;
   }, {});
-};
+}
 
-var saveInitialSnapshot = function (instance, key) {
+function saveInitialSnapshot(instance, key) {
   var state = instance.stores[key][STATE_CONTAINER];
   var initial = instance.deserialize(instance[INIT_SNAPSHOT]);
   initial[key] = state;
   instance[INIT_SNAPSHOT] = instance.serialize(initial);
   instance[LAST_SNAPSHOT] = instance[INIT_SNAPSHOT];
-};
+}
 
-var filterSnapshotOfStores = function (instance, serializedSnapshot, storeNames) {
+function filterSnapshotOfStores(instance, serializedSnapshot, storeNames) {
   var stores = instance.deserialize(serializedSnapshot);
   var storesToReset = storeNames.reduce(function (obj, name) {
     if (!stores[name]) {
@@ -1113,7 +1113,7 @@ var filterSnapshotOfStores = function (instance, serializedSnapshot, storeNames)
     return obj;
   }, {});
   return instance.serialize(storesToReset);
-};
+}
 
 function createStoreFromObject(alt, StoreModel, key) {
   var storeInstance = undefined;
@@ -1156,8 +1156,8 @@ function createStoreFromObject(alt, StoreModel, key) {
 }
 
 function createStoreFromClass(alt, StoreModel, key) {
-  for (var _len = arguments.length, args = Array(_len > 3 ? _len - 3 : 0), _key = 3; _key < _len; _key++) {
-    args[_key - 3] = arguments[_key];
+  for (var _len = arguments.length, argsForConstructor = Array(_len > 3 ? _len - 3 : 0), _key = 3; _key < _len; _key++) {
+    argsForConstructor[_key - 3] = arguments[_key];
   }
 
   var storeInstance = undefined;
@@ -1199,7 +1199,7 @@ function createStoreFromClass(alt, StoreModel, key) {
   Store.prototype[LISTENERS] = {};
   Store.prototype[PUBLIC_METHODS] = {};
 
-  var store = _applyConstructor(Store, args);
+  var store = _applyConstructor(Store, argsForConstructor);
 
   storeInstance = assign(new AltStore(alt.dispatcher, store, null, StoreModel), getInternalMethods(StoreModel, builtIns));
 
@@ -1302,8 +1302,8 @@ var Alt = (function () {
       value: function createActions(ActionsClass) {
         var _this8 = this;
 
-        for (var _len = arguments.length, args = Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
-          args[_key - 2] = arguments[_key];
+        for (var _len = arguments.length, argsForConstructor = Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
+          argsForConstructor[_key - 2] = arguments[_key];
         }
 
         var exportObj = arguments[1] === undefined ? {} : arguments[1];
@@ -1352,7 +1352,7 @@ var Alt = (function () {
               return ActionsGenerator;
             })(ActionsClass);
 
-            assign(actions, _applyConstructor(ActionsGenerator, args));
+            assign(actions, _applyConstructor(ActionsGenerator, argsForConstructor));
           })();
         } else {
           assign(actions, ActionsClass);
@@ -1425,7 +1425,13 @@ var Alt = (function () {
       // Instance type methods for injecting alt into your application as context
 
       value: function addActions(name, ActionsClass) {
-        this.actions[name] = Array.isArray(ActionsClass) ? this.generateActions.apply(this, ActionsClass) : this.createActions(ActionsClass);
+        var _ref;
+
+        for (var _len = arguments.length, args = Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
+          args[_key - 2] = arguments[_key];
+        }
+
+        this.actions[name] = Array.isArray(ActionsClass) ? this.generateActions.apply(this, ActionsClass) : (_ref = this).createActions.apply(_ref, [ActionsClass].concat(args));
       }
     },
     addStore: {

--- a/dist/alt-browser.js
+++ b/dist/alt-browser.js
@@ -733,6 +733,8 @@ module.exports = Object.assign || function (target, source) {
 
 var _interopRequire = function (obj) { return obj && obj.__esModule ? obj["default"] : obj; };
 
+var _applyConstructor = function (Constructor, args) { var instance = Object.create(Constructor.prototype); var result = Constructor.apply(instance, args); return result != null && (typeof result == "object" || typeof result == "function") ? result : instance; };
+
 var _get = function get(object, property, receiver) { var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc && desc.writable) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };
 
 var _inherits = function (subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; };
@@ -1113,7 +1115,7 @@ var filterSnapshotOfStores = function (instance, serializedSnapshot, storeNames)
   return instance.serialize(storesToReset);
 };
 
-var createStoreFromObject = function (alt, StoreModel, key, saveStore) {
+function createStoreFromObject(alt, StoreModel, key) {
   var storeInstance = undefined;
 
   var StoreProto = {};
@@ -1150,14 +1152,59 @@ var createStoreFromObject = function (alt, StoreModel, key, saveStore) {
   // create the instance and assign the public methods to the instance
   storeInstance = assign(new AltStore(alt.dispatcher, StoreProto, StoreProto.state, StoreModel), StoreProto.publicMethods);
 
-  /* istanbul ignore else */
-  if (saveStore) {
-    alt.stores[key] = storeInstance;
-    saveInitialSnapshot(alt, key);
+  return storeInstance;
+}
+
+function createStoreFromClass(alt, StoreModel, key) {
+  for (var _len = arguments.length, args = Array(_len > 3 ? _len - 3 : 0), _key = 3; _key < _len; _key++) {
+    args[_key - 3] = arguments[_key];
   }
 
+  var storeInstance = undefined;
+
+  // Creating a class here so we don't overload the provided store's
+  // prototype with the mixin behaviour and I'm extending from StoreModel
+  // so we can inherit any extensions from the provided store.
+
+  var Store = (function (_StoreModel) {
+    function Store() {
+      for (var _len2 = arguments.length, args = Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
+        args[_key2] = arguments[_key2];
+      }
+
+      _classCallCheck(this, Store);
+
+      _get(Object.getPrototypeOf(Store.prototype), "constructor", this).apply(this, args);
+    }
+
+    _inherits(Store, _StoreModel);
+
+    return Store;
+  })(StoreModel);
+
+  assign(Store.prototype, StoreMixinListeners, StoreMixinEssentials, {
+    _storeName: key,
+    alt: alt,
+    dispatcher: alt.dispatcher,
+    getInstance: function getInstance() {
+      return storeInstance;
+    },
+    setState: function setState(nextState) {
+      doSetState(this, storeInstance, nextState);
+    }
+  });
+
+  Store.prototype[ALL_LISTENERS] = [];
+  Store.prototype[LIFECYCLE] = {};
+  Store.prototype[LISTENERS] = {};
+  Store.prototype[PUBLIC_METHODS] = {};
+
+  var store = _applyConstructor(Store, args);
+
+  storeInstance = assign(new AltStore(alt.dispatcher, store, null, StoreModel), getInternalMethods(StoreModel, builtIns));
+
   return storeInstance;
-};
+}
 
 var Alt = (function () {
   function Alt() {
@@ -1179,14 +1226,25 @@ var Alt = (function () {
         this.dispatcher.dispatch({ action: action, data: data });
       }
     },
+    createUnsavedStore: {
+      value: function createUnsavedStore(StoreModel) {
+        for (var _len = arguments.length, args = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+          args[_key - 1] = arguments[_key];
+        }
+
+        var key = StoreModel.displayName || "";
+        return typeof StoreModel === "object" ? createStoreFromObject(this, StoreModel, key) : createStoreFromClass.apply(undefined, [this, StoreModel, key].concat(args));
+      }
+    },
     createStore: {
       value: function createStore(StoreModel, iden) {
-        var saveStore = arguments[2] === undefined ? true : arguments[2];
+        for (var _len = arguments.length, args = Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
+          args[_key - 2] = arguments[_key];
+        }
 
-        var storeInstance = undefined;
         var key = iden || StoreModel.name || StoreModel.displayName || "";
 
-        if (saveStore && (this.stores[key] || !key)) {
+        if (this.stores[key] || !key) {
           if (this.stores[key]) {
             warn("A store named " + key + " already exists, double check your store " + "names or pass in your own custom identifier for each store");
           } else {
@@ -1196,51 +1254,10 @@ var Alt = (function () {
           key = uid(this.stores, key);
         }
 
-        if (typeof StoreModel === "object") {
-          return createStoreFromObject(this, StoreModel, key, saveStore);
-        }
+        var storeInstance = typeof StoreModel === "object" ? createStoreFromObject(this, StoreModel, key) : createStoreFromClass.apply(undefined, [this, StoreModel, key].concat(args));
 
-        // Creating a class here so we don't overload the provided store's
-        // prototype with the mixin behaviour and I'm extending from StoreModel
-        // so we can inherit any extensions from the provided store.
-
-        var Store = (function (_StoreModel) {
-          function Store(alt) {
-            _classCallCheck(this, Store);
-
-            _get(Object.getPrototypeOf(Store.prototype), "constructor", this).call(this, alt);
-          }
-
-          _inherits(Store, _StoreModel);
-
-          return Store;
-        })(StoreModel);
-
-        assign(Store.prototype, StoreMixinListeners, StoreMixinEssentials, {
-          _storeName: key,
-          alt: this,
-          dispatcher: this.dispatcher,
-          getInstance: function getInstance() {
-            return storeInstance;
-          },
-          setState: function setState(nextState) {
-            doSetState(this, storeInstance, nextState);
-          }
-        });
-
-        Store.prototype[ALL_LISTENERS] = [];
-        Store.prototype[LIFECYCLE] = {};
-        Store.prototype[LISTENERS] = {};
-        Store.prototype[PUBLIC_METHODS] = {};
-
-        var store = new Store(this);
-
-        storeInstance = assign(new AltStore(this.dispatcher, store, null, StoreModel), getInternalMethods(StoreModel, builtIns));
-
-        if (saveStore) {
-          this.stores[key] = storeInstance;
-          saveInitialSnapshot(this, key);
-        }
+        this.stores[key] = storeInstance;
+        saveInitialSnapshot(this, key);
 
         return storeInstance;
       }
@@ -1285,6 +1302,10 @@ var Alt = (function () {
       value: function createActions(ActionsClass) {
         var _this8 = this;
 
+        for (var _len = arguments.length, args = Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
+          args[_key - 2] = arguments[_key];
+        }
+
         var exportObj = arguments[1] === undefined ? {} : arguments[1];
 
         var actions = {};
@@ -1295,10 +1316,14 @@ var Alt = (function () {
             assign(actions, getInternalMethods(ActionsClass.prototype, builtInProto));
 
             var ActionsGenerator = (function (_ActionsClass) {
-              function ActionsGenerator(alt) {
+              function ActionsGenerator() {
+                for (var _len2 = arguments.length, args = Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
+                  args[_key2] = arguments[_key2];
+                }
+
                 _classCallCheck(this, ActionsGenerator);
 
-                _get(Object.getPrototypeOf(ActionsGenerator.prototype), "constructor", this).call(this, alt);
+                _get(Object.getPrototypeOf(ActionsGenerator.prototype), "constructor", this).apply(this, args);
               }
 
               _inherits(ActionsGenerator, _ActionsClass);
@@ -1306,15 +1331,15 @@ var Alt = (function () {
               _createClass(ActionsGenerator, {
                 generateActions: {
                   value: function generateActions() {
-                    for (var _len = arguments.length, actionNames = Array(_len), _key = 0; _key < _len; _key++) {
-                      actionNames[_key] = arguments[_key];
+                    for (var _len2 = arguments.length, actionNames = Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
+                      actionNames[_key2] = arguments[_key2];
                     }
 
                     actionNames.forEach(function (actionName) {
                       // This is a function so we can later bind this to ActionCreator
                       actions[actionName] = function (x) {
-                        for (var _len2 = arguments.length, a = Array(_len2 > 1 ? _len2 - 1 : 0), _key2 = 1; _key2 < _len2; _key2++) {
-                          a[_key2 - 1] = arguments[_key2];
+                        for (var _len3 = arguments.length, a = Array(_len3 > 1 ? _len3 - 1 : 0), _key3 = 1; _key3 < _len3; _key3++) {
+                          a[_key3 - 1] = arguments[_key3];
                         }
 
                         this.dispatch(a.length ? [x].concat(a) : x);
@@ -1327,7 +1352,7 @@ var Alt = (function () {
               return ActionsGenerator;
             })(ActionsClass);
 
-            assign(actions, new ActionsGenerator(_this8));
+            assign(actions, _applyConstructor(ActionsGenerator, args));
           })();
         } else {
           assign(actions, ActionsClass);
@@ -1404,8 +1429,14 @@ var Alt = (function () {
       }
     },
     addStore: {
-      value: function addStore(name, StoreModel, saveStore) {
-        this.createStore(StoreModel, name, saveStore);
+      value: function addStore(name, StoreModel) {
+        var _ref;
+
+        for (var _len = arguments.length, args = Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
+          args[_key - 2] = arguments[_key];
+        }
+
+        (_ref = this).createStore.apply(_ref, [StoreModel, name].concat(args));
       }
     },
     getActions: {

--- a/dist/alt-with-runtime.js
+++ b/dist/alt-with-runtime.js
@@ -71,7 +71,7 @@ function NoopClass() {}
 var builtIns = Object.getOwnPropertyNames(NoopClass);
 var builtInProto = Object.getOwnPropertyNames(NoopClass.prototype);
 
-var getInternalMethods = function (obj, excluded) {
+function getInternalMethods(obj, excluded) {
   return Object.getOwnPropertyNames(obj).reduce(function (value, m) {
     if (excluded.indexOf(m) !== -1) {
       return value;
@@ -80,7 +80,7 @@ var getInternalMethods = function (obj, excluded) {
     value[m] = obj[m];
     return value;
   }, {});
-};
+}
 
 var AltStore = (function () {
   function AltStore(dispatcher, model, state, StoreModel) {
@@ -317,7 +317,7 @@ var StoreMixinEssentials = {
   }
 };
 
-var setAppState = function (instance, data, onStore) {
+function setAppState(instance, data, onStore) {
   var obj = instance.deserialize(data);
   Object.keys(obj).forEach(function (key) {
     var store = instance.stores[key];
@@ -329,9 +329,9 @@ var setAppState = function (instance, data, onStore) {
       onStore(store);
     }
   });
-};
+}
 
-var snapshot = function (instance) {
+function snapshot(instance) {
   for (var _len = arguments.length, storeNames = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
     storeNames[_key - 1] = arguments[_key];
   }
@@ -346,17 +346,17 @@ var snapshot = function (instance) {
     obj[key] = customSnapshot ? customSnapshot : store.getState();
     return obj;
   }, {});
-};
+}
 
-var saveInitialSnapshot = function (instance, key) {
+function saveInitialSnapshot(instance, key) {
   var state = instance.stores[key][STATE_CONTAINER];
   var initial = instance.deserialize(instance[INIT_SNAPSHOT]);
   initial[key] = state;
   instance[INIT_SNAPSHOT] = instance.serialize(initial);
   instance[LAST_SNAPSHOT] = instance[INIT_SNAPSHOT];
-};
+}
 
-var filterSnapshotOfStores = function (instance, serializedSnapshot, storeNames) {
+function filterSnapshotOfStores(instance, serializedSnapshot, storeNames) {
   var stores = instance.deserialize(serializedSnapshot);
   var storesToReset = storeNames.reduce(function (obj, name) {
     if (!stores[name]) {
@@ -366,7 +366,7 @@ var filterSnapshotOfStores = function (instance, serializedSnapshot, storeNames)
     return obj;
   }, {});
   return instance.serialize(storesToReset);
-};
+}
 
 function createStoreFromObject(alt, StoreModel, key) {
   var storeInstance = undefined;
@@ -409,8 +409,8 @@ function createStoreFromObject(alt, StoreModel, key) {
 }
 
 function createStoreFromClass(alt, StoreModel, key) {
-  for (var _len = arguments.length, args = Array(_len > 3 ? _len - 3 : 0), _key = 3; _key < _len; _key++) {
-    args[_key - 3] = arguments[_key];
+  for (var _len = arguments.length, argsForConstructor = Array(_len > 3 ? _len - 3 : 0), _key = 3; _key < _len; _key++) {
+    argsForConstructor[_key - 3] = arguments[_key];
   }
 
   var storeInstance = undefined;
@@ -451,7 +451,7 @@ function createStoreFromClass(alt, StoreModel, key) {
   Store.prototype[LISTENERS] = {};
   Store.prototype[PUBLIC_METHODS] = {};
 
-  var store = babelHelpers.applyConstructor(Store, args);
+  var store = babelHelpers.applyConstructor(Store, argsForConstructor);
 
   storeInstance = assign(new AltStore(alt.dispatcher, store, null, StoreModel), getInternalMethods(StoreModel, builtIns));
 
@@ -551,8 +551,8 @@ var Alt = (function () {
       value: function createActions(ActionsClass) {
         var _this8 = this;
 
-        for (var _len = arguments.length, args = Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
-          args[_key - 2] = arguments[_key];
+        for (var _len = arguments.length, argsForConstructor = Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
+          argsForConstructor[_key - 2] = arguments[_key];
         }
 
         var exportObj = arguments[1] === undefined ? {} : arguments[1];
@@ -599,7 +599,7 @@ var Alt = (function () {
               return ActionsGenerator;
             })(ActionsClass);
 
-            assign(actions, babelHelpers.applyConstructor(ActionsGenerator, args));
+            assign(actions, babelHelpers.applyConstructor(ActionsGenerator, argsForConstructor));
           })();
         } else {
           assign(actions, ActionsClass);
@@ -672,7 +672,11 @@ var Alt = (function () {
       // Instance type methods for injecting alt into your application as context
 
       value: function addActions(name, ActionsClass) {
-        this.actions[name] = Array.isArray(ActionsClass) ? this.generateActions.apply(this, ActionsClass) : this.createActions(ActionsClass);
+        for (var _len = arguments.length, args = Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
+          args[_key - 2] = arguments[_key];
+        }
+
+        this.actions[name] = Array.isArray(ActionsClass) ? this.generateActions.apply(this, ActionsClass) : this.createActions.apply(this, [ActionsClass].concat(args));
       }
     },
     addStore: {

--- a/dist/alt.js
+++ b/dist/alt.js
@@ -85,7 +85,7 @@ function NoopClass() {}
 var builtIns = Object.getOwnPropertyNames(NoopClass);
 var builtInProto = Object.getOwnPropertyNames(NoopClass.prototype);
 
-var getInternalMethods = function (obj, excluded) {
+function getInternalMethods(obj, excluded) {
   return Object.getOwnPropertyNames(obj).reduce(function (value, m) {
     if (excluded.indexOf(m) !== -1) {
       return value;
@@ -94,7 +94,7 @@ var getInternalMethods = function (obj, excluded) {
     value[m] = obj[m];
     return value;
   }, {});
-};
+}
 
 var AltStore = (function () {
   function AltStore(dispatcher, model, state, StoreModel) {
@@ -333,7 +333,7 @@ var StoreMixinEssentials = {
   }
 };
 
-var setAppState = function (instance, data, onStore) {
+function setAppState(instance, data, onStore) {
   var obj = instance.deserialize(data);
   Object.keys(obj).forEach(function (key) {
     var store = instance.stores[key];
@@ -345,9 +345,9 @@ var setAppState = function (instance, data, onStore) {
       onStore(store);
     }
   });
-};
+}
 
-var snapshot = function (instance) {
+function snapshot(instance) {
   for (var _len = arguments.length, storeNames = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
     storeNames[_key - 1] = arguments[_key];
   }
@@ -362,17 +362,17 @@ var snapshot = function (instance) {
     obj[key] = customSnapshot ? customSnapshot : store.getState();
     return obj;
   }, {});
-};
+}
 
-var saveInitialSnapshot = function (instance, key) {
+function saveInitialSnapshot(instance, key) {
   var state = instance.stores[key][STATE_CONTAINER];
   var initial = instance.deserialize(instance[INIT_SNAPSHOT]);
   initial[key] = state;
   instance[INIT_SNAPSHOT] = instance.serialize(initial);
   instance[LAST_SNAPSHOT] = instance[INIT_SNAPSHOT];
-};
+}
 
-var filterSnapshotOfStores = function (instance, serializedSnapshot, storeNames) {
+function filterSnapshotOfStores(instance, serializedSnapshot, storeNames) {
   var stores = instance.deserialize(serializedSnapshot);
   var storesToReset = storeNames.reduce(function (obj, name) {
     if (!stores[name]) {
@@ -382,7 +382,7 @@ var filterSnapshotOfStores = function (instance, serializedSnapshot, storeNames)
     return obj;
   }, {});
   return instance.serialize(storesToReset);
-};
+}
 
 function createStoreFromObject(alt, StoreModel, key) {
   var storeInstance = undefined;
@@ -425,8 +425,8 @@ function createStoreFromObject(alt, StoreModel, key) {
 }
 
 function createStoreFromClass(alt, StoreModel, key) {
-  for (var _len = arguments.length, args = Array(_len > 3 ? _len - 3 : 0), _key = 3; _key < _len; _key++) {
-    args[_key - 3] = arguments[_key];
+  for (var _len = arguments.length, argsForConstructor = Array(_len > 3 ? _len - 3 : 0), _key = 3; _key < _len; _key++) {
+    argsForConstructor[_key - 3] = arguments[_key];
   }
 
   var storeInstance = undefined;
@@ -468,7 +468,7 @@ function createStoreFromClass(alt, StoreModel, key) {
   Store.prototype[LISTENERS] = {};
   Store.prototype[PUBLIC_METHODS] = {};
 
-  var store = _applyConstructor(Store, args);
+  var store = _applyConstructor(Store, argsForConstructor);
 
   storeInstance = assign(new AltStore(alt.dispatcher, store, null, StoreModel), getInternalMethods(StoreModel, builtIns));
 
@@ -569,8 +569,8 @@ var Alt = (function () {
       value: function createActions(ActionsClass) {
         var _this8 = this;
 
-        for (var _len = arguments.length, args = Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
-          args[_key - 2] = arguments[_key];
+        for (var _len = arguments.length, argsForConstructor = Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
+          argsForConstructor[_key - 2] = arguments[_key];
         }
 
         var exportObj = arguments[1] === undefined ? {} : arguments[1];
@@ -619,7 +619,7 @@ var Alt = (function () {
               return ActionsGenerator;
             })(ActionsClass);
 
-            assign(actions, _applyConstructor(ActionsGenerator, args));
+            assign(actions, _applyConstructor(ActionsGenerator, argsForConstructor));
           })();
         } else {
           assign(actions, ActionsClass);
@@ -692,7 +692,11 @@ var Alt = (function () {
       // Instance type methods for injecting alt into your application as context
 
       value: function addActions(name, ActionsClass) {
-        this.actions[name] = Array.isArray(ActionsClass) ? this.generateActions.apply(this, ActionsClass) : this.createActions(ActionsClass);
+        for (var _len = arguments.length, args = Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
+          args[_key - 2] = arguments[_key];
+        }
+
+        this.actions[name] = Array.isArray(ActionsClass) ? this.generateActions.apply(this, ActionsClass) : this.createActions.apply(this, [ActionsClass].concat(args));
       }
     },
     addStore: {

--- a/dist/alt.js
+++ b/dist/alt.js
@@ -2,6 +2,8 @@
 
 var _interopRequire = function (obj) { return obj && obj.__esModule ? obj["default"] : obj; };
 
+var _applyConstructor = function (Constructor, args) { var instance = Object.create(Constructor.prototype); var result = Constructor.apply(instance, args); return result != null && (typeof result == "object" || typeof result == "function") ? result : instance; };
+
 var _get = function get(object, property, receiver) { var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc && desc.writable) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };
 
 var _inherits = function (subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; };
@@ -382,7 +384,7 @@ var filterSnapshotOfStores = function (instance, serializedSnapshot, storeNames)
   return instance.serialize(storesToReset);
 };
 
-var createStoreFromObject = function (alt, StoreModel, key, saveStore) {
+function createStoreFromObject(alt, StoreModel, key) {
   var storeInstance = undefined;
 
   var StoreProto = {};
@@ -419,14 +421,59 @@ var createStoreFromObject = function (alt, StoreModel, key, saveStore) {
   // create the instance and assign the public methods to the instance
   storeInstance = assign(new AltStore(alt.dispatcher, StoreProto, StoreProto.state, StoreModel), StoreProto.publicMethods);
 
-  /* istanbul ignore else */
-  if (saveStore) {
-    alt.stores[key] = storeInstance;
-    saveInitialSnapshot(alt, key);
+  return storeInstance;
+}
+
+function createStoreFromClass(alt, StoreModel, key) {
+  for (var _len = arguments.length, args = Array(_len > 3 ? _len - 3 : 0), _key = 3; _key < _len; _key++) {
+    args[_key - 3] = arguments[_key];
   }
 
+  var storeInstance = undefined;
+
+  // Creating a class here so we don't overload the provided store's
+  // prototype with the mixin behaviour and I'm extending from StoreModel
+  // so we can inherit any extensions from the provided store.
+
+  var Store = (function (_StoreModel) {
+    function Store() {
+      for (var _len2 = arguments.length, args = Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
+        args[_key2] = arguments[_key2];
+      }
+
+      _classCallCheck(this, Store);
+
+      _get(Object.getPrototypeOf(Store.prototype), "constructor", this).apply(this, args);
+    }
+
+    _inherits(Store, _StoreModel);
+
+    return Store;
+  })(StoreModel);
+
+  assign(Store.prototype, StoreMixinListeners, StoreMixinEssentials, {
+    _storeName: key,
+    alt: alt,
+    dispatcher: alt.dispatcher,
+    getInstance: function getInstance() {
+      return storeInstance;
+    },
+    setState: function setState(nextState) {
+      doSetState(this, storeInstance, nextState);
+    }
+  });
+
+  Store.prototype[ALL_LISTENERS] = [];
+  Store.prototype[LIFECYCLE] = {};
+  Store.prototype[LISTENERS] = {};
+  Store.prototype[PUBLIC_METHODS] = {};
+
+  var store = _applyConstructor(Store, args);
+
+  storeInstance = assign(new AltStore(alt.dispatcher, store, null, StoreModel), getInternalMethods(StoreModel, builtIns));
+
   return storeInstance;
-};
+}
 
 var Alt = (function () {
   function Alt() {
@@ -448,14 +495,25 @@ var Alt = (function () {
         this.dispatcher.dispatch({ action: action, data: data });
       }
     },
+    createUnsavedStore: {
+      value: function createUnsavedStore(StoreModel) {
+        for (var _len = arguments.length, args = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+          args[_key - 1] = arguments[_key];
+        }
+
+        var key = StoreModel.displayName || "";
+        return typeof StoreModel === "object" ? createStoreFromObject(this, StoreModel, key) : createStoreFromClass.apply(undefined, [this, StoreModel, key].concat(args));
+      }
+    },
     createStore: {
       value: function createStore(StoreModel, iden) {
-        var saveStore = arguments[2] === undefined ? true : arguments[2];
+        for (var _len = arguments.length, args = Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
+          args[_key - 2] = arguments[_key];
+        }
 
-        var storeInstance = undefined;
         var key = iden || StoreModel.name || StoreModel.displayName || "";
 
-        if (saveStore && (this.stores[key] || !key)) {
+        if (this.stores[key] || !key) {
           if (this.stores[key]) {
             warn("A store named " + key + " already exists, double check your store " + "names or pass in your own custom identifier for each store");
           } else {
@@ -465,51 +523,10 @@ var Alt = (function () {
           key = uid(this.stores, key);
         }
 
-        if (typeof StoreModel === "object") {
-          return createStoreFromObject(this, StoreModel, key, saveStore);
-        }
+        var storeInstance = typeof StoreModel === "object" ? createStoreFromObject(this, StoreModel, key) : createStoreFromClass.apply(undefined, [this, StoreModel, key].concat(args));
 
-        // Creating a class here so we don't overload the provided store's
-        // prototype with the mixin behaviour and I'm extending from StoreModel
-        // so we can inherit any extensions from the provided store.
-
-        var Store = (function (_StoreModel) {
-          function Store(alt) {
-            _classCallCheck(this, Store);
-
-            _get(Object.getPrototypeOf(Store.prototype), "constructor", this).call(this, alt);
-          }
-
-          _inherits(Store, _StoreModel);
-
-          return Store;
-        })(StoreModel);
-
-        assign(Store.prototype, StoreMixinListeners, StoreMixinEssentials, {
-          _storeName: key,
-          alt: this,
-          dispatcher: this.dispatcher,
-          getInstance: function getInstance() {
-            return storeInstance;
-          },
-          setState: function setState(nextState) {
-            doSetState(this, storeInstance, nextState);
-          }
-        });
-
-        Store.prototype[ALL_LISTENERS] = [];
-        Store.prototype[LIFECYCLE] = {};
-        Store.prototype[LISTENERS] = {};
-        Store.prototype[PUBLIC_METHODS] = {};
-
-        var store = new Store(this);
-
-        storeInstance = assign(new AltStore(this.dispatcher, store, null, StoreModel), getInternalMethods(StoreModel, builtIns));
-
-        if (saveStore) {
-          this.stores[key] = storeInstance;
-          saveInitialSnapshot(this, key);
-        }
+        this.stores[key] = storeInstance;
+        saveInitialSnapshot(this, key);
 
         return storeInstance;
       }
@@ -552,6 +569,10 @@ var Alt = (function () {
       value: function createActions(ActionsClass) {
         var _this8 = this;
 
+        for (var _len = arguments.length, args = Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
+          args[_key - 2] = arguments[_key];
+        }
+
         var exportObj = arguments[1] === undefined ? {} : arguments[1];
 
         var actions = {};
@@ -562,10 +583,14 @@ var Alt = (function () {
             assign(actions, getInternalMethods(ActionsClass.prototype, builtInProto));
 
             var ActionsGenerator = (function (_ActionsClass) {
-              function ActionsGenerator(alt) {
+              function ActionsGenerator() {
+                for (var _len2 = arguments.length, args = Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
+                  args[_key2] = arguments[_key2];
+                }
+
                 _classCallCheck(this, ActionsGenerator);
 
-                _get(Object.getPrototypeOf(ActionsGenerator.prototype), "constructor", this).call(this, alt);
+                _get(Object.getPrototypeOf(ActionsGenerator.prototype), "constructor", this).apply(this, args);
               }
 
               _inherits(ActionsGenerator, _ActionsClass);
@@ -573,15 +598,15 @@ var Alt = (function () {
               _createClass(ActionsGenerator, {
                 generateActions: {
                   value: function generateActions() {
-                    for (var _len = arguments.length, actionNames = Array(_len), _key = 0; _key < _len; _key++) {
-                      actionNames[_key] = arguments[_key];
+                    for (var _len2 = arguments.length, actionNames = Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
+                      actionNames[_key2] = arguments[_key2];
                     }
 
                     actionNames.forEach(function (actionName) {
                       // This is a function so we can later bind this to ActionCreator
                       actions[actionName] = function (x) {
-                        for (var _len2 = arguments.length, a = Array(_len2 > 1 ? _len2 - 1 : 0), _key2 = 1; _key2 < _len2; _key2++) {
-                          a[_key2 - 1] = arguments[_key2];
+                        for (var _len3 = arguments.length, a = Array(_len3 > 1 ? _len3 - 1 : 0), _key3 = 1; _key3 < _len3; _key3++) {
+                          a[_key3 - 1] = arguments[_key3];
                         }
 
                         this.dispatch(a.length ? [x].concat(a) : x);
@@ -594,7 +619,7 @@ var Alt = (function () {
               return ActionsGenerator;
             })(ActionsClass);
 
-            assign(actions, new ActionsGenerator(_this8));
+            assign(actions, _applyConstructor(ActionsGenerator, args));
           })();
         } else {
           assign(actions, ActionsClass);
@@ -671,8 +696,12 @@ var Alt = (function () {
       }
     },
     addStore: {
-      value: function addStore(name, StoreModel, saveStore) {
-        this.createStore(StoreModel, name, saveStore);
+      value: function addStore(name, StoreModel) {
+        for (var _len = arguments.length, args = Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
+          args[_key - 2] = arguments[_key];
+        }
+
+        this.createStore.apply(this, [StoreModel, name].concat(args));
       }
     },
     getActions: {

--- a/src/alt.js
+++ b/src/alt.js
@@ -76,7 +76,7 @@ function NoopClass() { }
 const builtIns = Object.getOwnPropertyNames(NoopClass)
 const builtInProto = Object.getOwnPropertyNames(NoopClass.prototype)
 
-const getInternalMethods = (obj, excluded) => {
+function getInternalMethods(obj, excluded) {
   return Object.getOwnPropertyNames(obj).reduce((value, m) => {
     if (excluded.indexOf(m) !== -1) {
       return value
@@ -323,7 +323,7 @@ const StoreMixinEssentials = {
   }
 }
 
-const setAppState = (instance, data, onStore) => {
+function setAppState(instance, data, onStore) {
   const obj = instance.deserialize(data)
   Object.keys(obj).forEach((key) => {
     const store = instance.stores[key]
@@ -337,7 +337,7 @@ const setAppState = (instance, data, onStore) => {
   })
 }
 
-const snapshot = (instance, ...storeNames) => {
+function snapshot(instance, ...storeNames) {
   const stores = storeNames.length ? storeNames : Object.keys(instance.stores)
   return stores.reduce((obj, key) => {
     const store = instance.stores[key]
@@ -350,7 +350,7 @@ const snapshot = (instance, ...storeNames) => {
   }, {})
 }
 
-const saveInitialSnapshot = (instance, key) => {
+function saveInitialSnapshot(instance, key) {
   const state = instance.stores[key][STATE_CONTAINER]
   const initial = instance.deserialize(instance[INIT_SNAPSHOT])
   initial[key] = state
@@ -358,7 +358,7 @@ const saveInitialSnapshot = (instance, key) => {
   instance[LAST_SNAPSHOT] = instance[INIT_SNAPSHOT]
 }
 
-const filterSnapshotOfStores = (instance, serializedSnapshot, storeNames) => {
+function filterSnapshotOfStores(instance, serializedSnapshot, storeNames) {
   const stores = instance.deserialize(serializedSnapshot)
   const storesToReset = storeNames.reduce((obj, name) => {
     if (!stores[name]) {
@@ -413,7 +413,7 @@ function createStoreFromObject(alt, StoreModel, key) {
   return storeInstance
 }
 
-function createStoreFromClass(alt, StoreModel, key, ...args) {
+function createStoreFromClass(alt, StoreModel, key, ...argsForConstructor) {
   let storeInstance
 
   // Creating a class here so we don't overload the provided store's
@@ -442,7 +442,7 @@ function createStoreFromClass(alt, StoreModel, key, ...args) {
   Store.prototype[LISTENERS] = {}
   Store.prototype[PUBLIC_METHODS] = {}
 
-  const store = new Store(...args)
+  const store = new Store(...argsForConstructor)
 
   storeInstance = assign(
     new AltStore(alt.dispatcher, store, null, StoreModel),
@@ -523,7 +523,7 @@ class Alt {
     return action
   }
 
-  createActions(ActionsClass, exportObj = {}, ...args) {
+  createActions(ActionsClass, exportObj = {}, ...argsForConstructor) {
     const actions = {}
     const key = ActionsClass.name || ActionsClass.displayName || ''
 
@@ -544,7 +544,7 @@ class Alt {
         }
       }
 
-      assign(actions, new ActionsGenerator(...args))
+      assign(actions, new ActionsGenerator(...argsForConstructor))
     } else {
       assign(actions, ActionsClass)
     }
@@ -604,10 +604,10 @@ class Alt {
 
   // Instance type methods for injecting alt into your application as context
 
-  addActions(name, ActionsClass) {
+  addActions(name, ActionsClass, ...args) {
     this.actions[name] = Array.isArray(ActionsClass)
       ? this.generateActions.apply(this, ActionsClass)
-      : this.createActions(ActionsClass)
+      : this.createActions(ActionsClass, ...args)
   }
 
   addStore(name, StoreModel, ...args) {

--- a/src/alt.js
+++ b/src/alt.js
@@ -370,7 +370,7 @@ const filterSnapshotOfStores = (instance, serializedSnapshot, storeNames) => {
   return instance.serialize(storesToReset)
 }
 
-const createStoreFromObject = (alt, StoreModel, key, saveStore) => {
+function createStoreFromObject(alt, StoreModel, key) {
   let storeInstance
 
   const StoreProto = {}
@@ -410,11 +410,44 @@ const createStoreFromObject = (alt, StoreModel, key, saveStore) => {
     StoreProto.publicMethods
   )
 
-  /* istanbul ignore else */
-  if (saveStore) {
-    alt.stores[key] = storeInstance
-    saveInitialSnapshot(alt, key)
+  return storeInstance
+}
+
+function createStoreFromClass(alt, StoreModel, key, ...args) {
+  let storeInstance
+
+  // Creating a class here so we don't overload the provided store's
+  // prototype with the mixin behaviour and I'm extending from StoreModel
+  // so we can inherit any extensions from the provided store.
+  class Store extends StoreModel {
+    constructor(...args) {
+      super(...args)
+    }
   }
+
+  assign(Store.prototype, StoreMixinListeners, StoreMixinEssentials, {
+    _storeName: key,
+    alt: alt,
+    dispatcher: alt.dispatcher,
+    getInstance() {
+      return storeInstance
+    },
+    setState(nextState) {
+      doSetState(this, storeInstance, nextState)
+    }
+  })
+
+  Store.prototype[ALL_LISTENERS] = []
+  Store.prototype[LIFECYCLE] = {}
+  Store.prototype[LISTENERS] = {}
+  Store.prototype[PUBLIC_METHODS] = {}
+
+  const store = new Store(...args)
+
+  storeInstance = assign(
+    new AltStore(alt.dispatcher, store, null, StoreModel),
+    getInternalMethods(StoreModel, builtIns)
+  )
 
   return storeInstance
 }
@@ -433,11 +466,17 @@ class Alt {
     this.dispatcher.dispatch({ action, data })
   }
 
-  createStore(StoreModel, iden, saveStore = true) {
-    let storeInstance
+  createUnsavedStore(StoreModel, ...args) {
+    const key = StoreModel.displayName || ''
+    return typeof StoreModel === 'object'
+      ? createStoreFromObject(this, StoreModel, key)
+      : createStoreFromClass(this, StoreModel, key, ...args)
+  }
+
+  createStore(StoreModel, iden, ...args) {
     let key = iden || StoreModel.name || StoreModel.displayName || ''
 
-    if (saveStore && (this.stores[key] || !key)) {
+    if (this.stores[key] || !key) {
       if (this.stores[key]) {
         warn(
           `A store named ${key} already exists, double check your store ` +
@@ -450,47 +489,12 @@ class Alt {
       key = uid(this.stores, key)
     }
 
-    if (typeof StoreModel === 'object') {
-      return createStoreFromObject(this, StoreModel, key, saveStore)
-    }
+    const storeInstance = typeof StoreModel === 'object'
+      ? createStoreFromObject(this, StoreModel, key)
+      : createStoreFromClass(this, StoreModel, key, ...args)
 
-    // Creating a class here so we don't overload the provided store's
-    // prototype with the mixin behaviour and I'm extending from StoreModel
-    // so we can inherit any extensions from the provided store.
-    class Store extends StoreModel {
-      constructor(alt) {
-        super(alt)
-      }
-    }
-
-    assign(Store.prototype, StoreMixinListeners, StoreMixinEssentials, {
-      _storeName: key,
-      alt: this,
-      dispatcher: this.dispatcher,
-      getInstance() {
-        return storeInstance
-      },
-      setState(nextState) {
-        doSetState(this, storeInstance, nextState)
-      }
-    })
-
-    Store.prototype[ALL_LISTENERS] = []
-    Store.prototype[LIFECYCLE] = {}
-    Store.prototype[LISTENERS] = {}
-    Store.prototype[PUBLIC_METHODS] = {}
-
-    const store = new Store(this)
-
-    storeInstance = assign(
-      new AltStore(this.dispatcher, store, null, StoreModel),
-      getInternalMethods(StoreModel, builtIns)
-    )
-
-    if (saveStore) {
-      this.stores[key] = storeInstance
-      saveInitialSnapshot(this, key)
-    }
+    this.stores[key] = storeInstance
+    saveInitialSnapshot(this, key)
 
     return storeInstance
   }
@@ -519,15 +523,15 @@ class Alt {
     return action
   }
 
-  createActions(ActionsClass, exportObj = {}) {
+  createActions(ActionsClass, exportObj = {}, ...args) {
     const actions = {}
     const key = ActionsClass.name || ActionsClass.displayName || ''
 
     if (typeof ActionsClass === 'function') {
       assign(actions, getInternalMethods(ActionsClass.prototype, builtInProto))
       class ActionsGenerator extends ActionsClass {
-        constructor(alt) {
-          super(alt)
+        constructor(...args) {
+          super(...args)
         }
 
         generateActions(...actionNames) {
@@ -540,7 +544,7 @@ class Alt {
         }
       }
 
-      assign(actions, new ActionsGenerator(this))
+      assign(actions, new ActionsGenerator(...args))
     } else {
       assign(actions, ActionsClass)
     }
@@ -606,8 +610,8 @@ class Alt {
       : this.createActions(ActionsClass)
   }
 
-  addStore(name, StoreModel, saveStore) {
-    this.createStore(StoreModel, name, saveStore)
+  addStore(name, StoreModel, ...args) {
+    this.createStore(StoreModel, name, ...args)
   }
 
   getActions(name) {

--- a/test/index.js
+++ b/test/index.js
@@ -1254,7 +1254,7 @@ const tests = {
   'do not include store in snapshots'() {
     function NoBootstrap() { }
 
-    alt.createStore(NoBootstrap, 'NoBootstrap', false)
+    alt.createUnsavedStore(NoBootstrap, 'NoBootstrap')
 
     const snapshot = JSON.parse(alt.takeSnapshot())
 

--- a/test/index.js
+++ b/test/index.js
@@ -326,9 +326,9 @@ const interceptSnapshotStore = alt.createStore(InterceptSnapshotStore)
 class AltInstance extends Alt {
   constructor() {
     super()
-    this.addActions('myActions', MyActions)
+    this.addActions('myActions', MyActions, this)
     this.addActions('fauxActions', ['one', 'two'])
-    this.addStore('myStore', MyStore)
+    this.addStore('myStore', MyStore, this)
   }
 }
 
@@ -1256,9 +1256,18 @@ const tests = {
 
     alt.createUnsavedStore(NoBootstrap, 'NoBootstrap')
 
-    const snapshot = JSON.parse(alt.takeSnapshot())
+    let snapshot = JSON.parse(alt.takeSnapshot())
 
     assert.isUndefined(snapshot.NoBootstrap, 'Store does not exist in snapshots')
+    assert.isObject(snapshot.AltSecondStore, 'AltSecondStore exists')
+
+    alt.createUnsavedStore({
+      displayName: 'NoBootstrapObject'
+    })
+
+    snapshot = JSON.parse(alt.takeSnapshot())
+
+    assert.isUndefined(snapshot.NoBootstrapObject, 'Store does not exist in snapshots')
     assert.isObject(snapshot.AltSecondStore, 'AltSecondStore exists')
   },
 

--- a/test/stores-get-alt.js
+++ b/test/stores-get-alt.js
@@ -11,7 +11,7 @@ export default {
       }
     }
 
-    alt.createStore(MyStore)
+    alt.createStore(MyStore, 'MyStore', alt)
   },
 
   'the actions get the alt instance'() {
@@ -21,6 +21,6 @@ export default {
       }
     }
 
-    alt.createActions(MyActions)
+    alt.createActions(MyActions, undefined, alt)
   }
 }

--- a/utils/makeFinalStore.js
+++ b/utils/makeFinalStore.js
@@ -37,5 +37,5 @@ function FinalStore() {
 }
 
 function makeFinalStore(alt) {
-  return alt.createStore(FinalStore, 'AltFinalStore', false)
+  return alt.createUnsavedStore(FinalStore)
 }


### PR DESCRIPTION
Alt's first breaking change.

I'm thinking we should be able to pass in custom items into the store and actions constructors so this would make the following changes:

`alt.createStore` just takes a StoreModel and a name, all other arguments are passed to the store's constructor.

`alt.createActions` takes in the ActionsClass, an optional object to export actions to, all other args are passed to the action's constructor.

`alt.addActions` is name, class, and ...args

`alt.addStore` is name, class, and ...args

This removes the saveStore boolean that was previously present for addStore and createStore, if you wish to create a store that will not be part of bootstrapping then a new method `alt.createUnsavedStore` has been added.

The other breaking change is that actions and stores no longer have the alt instance passed in as the first argument implicitly, you now have to explicitly pass it in. This shouldn't be a huge deal since it's available through `this.alt` anyway.

This adds ~20LOC to core.

Thoughts?