### PR TITLE
Catch errors in stores

### DIFF
--- a/README.md
+++ b/README.md
@@ -651,6 +651,28 @@ class Store {
 }
 ```
 
+`error` is called whenever an error occurs in your store during a dispatch. You can use this listener to catch errors and perform any cleanup tasks.
+
+```js
+class Store {
+  constructor() {
+    this.on('error', (err, actionName, payloadData, currentState) => {
+      if (actionName === MyActions.fire) {
+        logError(err, payloadData);
+      }
+    });
+
+    this.bindListeners({
+      handleFire: MyActions.fire
+    });
+  }
+
+  handleFire() {
+    throw new Error('Something is broken');
+  }
+}
+```
+
 ### Single Dispatcher
 
 A single dispatcher instance is made available for listening to all events passing through. You can access this via the `dispatcher` property: `alt.dispatcher`

--- a/dist/alt-browser-with-addons.js
+++ b/dist/alt-browser-with-addons.js
@@ -1078,7 +1078,18 @@ var AltStore = (function () {
       }
       if (model[LISTENERS][payload.action]) {
         _this8[SET_STATE] = false;
-        var result = model[LISTENERS][payload.action](payload.data);
+        var result = false;
+
+        try {
+          result = model[LISTENERS][payload.action](payload.data);
+        } catch (e) {
+          if (_this8[LIFECYCLE].error) {
+            _this8[LIFECYCLE].error(e, payload.action.toString(), payload.data, _this8[STATE_CONTAINER]);
+          } else {
+            throw e;
+          }
+        }
+
         if (result !== false && _this8[SET_STATE] === false) {
           _this8.emitChange();
         }

--- a/dist/alt-browser.js
+++ b/dist/alt-browser.js
@@ -822,7 +822,18 @@ var AltStore = (function () {
       }
       if (model[LISTENERS][payload.action]) {
         _this8[SET_STATE] = false;
-        var result = model[LISTENERS][payload.action](payload.data);
+        var result = false;
+
+        try {
+          result = model[LISTENERS][payload.action](payload.data);
+        } catch (e) {
+          if (_this8[LIFECYCLE].error) {
+            _this8[LIFECYCLE].error(e, payload.action.toString(), payload.data, _this8[STATE_CONTAINER]);
+          } else {
+            throw e;
+          }
+        }
+
         if (result !== false && _this8[SET_STATE] === false) {
           _this8.emitChange();
         }

--- a/dist/alt-with-runtime.js
+++ b/dist/alt-with-runtime.js
@@ -79,7 +79,18 @@ var AltStore = (function () {
       }
       if (model[LISTENERS][payload.action]) {
         _this8[SET_STATE] = false;
-        var result = model[LISTENERS][payload.action](payload.data);
+        var result = false;
+
+        try {
+          result = model[LISTENERS][payload.action](payload.data);
+        } catch (e) {
+          if (_this8[LIFECYCLE].error) {
+            _this8[LIFECYCLE].error(e, payload.action.toString(), payload.data, _this8[STATE_CONTAINER]);
+          } else {
+            throw e;
+          }
+        }
+
         if (result !== false && _this8[SET_STATE] === false) {
           _this8.emitChange();
         }

--- a/dist/alt.js
+++ b/dist/alt.js
@@ -91,7 +91,18 @@ var AltStore = (function () {
       }
       if (model[LISTENERS][payload.action]) {
         _this8[SET_STATE] = false;
-        var result = model[LISTENERS][payload.action](payload.data);
+        var result = false;
+
+        try {
+          result = model[LISTENERS][payload.action](payload.data);
+        } catch (e) {
+          if (_this8[LIFECYCLE].error) {
+            _this8[LIFECYCLE].error(e, payload.action.toString(), payload.data, _this8[STATE_CONTAINER]);
+          } else {
+            throw e;
+          }
+        }
+
         if (result !== false && _this8[SET_STATE] === false) {
           _this8.emitChange();
         }

--- a/docs/lifecycleListeners.md
+++ b/docs/lifecycleListeners.md
@@ -95,3 +95,27 @@ class Store {
   }
 }
 ```
+
+## Error
+
+`error` is called whenever an error occurs in your store during a dispatch. You can use this listener to catch errors and perform any cleanup tasks.
+
+```js
+class Store {
+  constructor() {
+    this.on('error', (err, actionName, payloadData, currentState) => {
+      if (actionName === MyActions.fire) {
+        logError(err, payloadData);
+      }
+    });
+
+    this.bindListeners({
+      handleFire: MyActions.fire
+    });
+  }
+
+  handleFire() {
+    throw new Error('Something is broken');
+  }
+}
+```

--- a/src/alt.js
+++ b/src/alt.js
@@ -78,7 +78,23 @@ class AltStore {
       }
       if (model[LISTENERS][payload.action]) {
         this[SET_STATE] = false
-        const result = model[LISTENERS][payload.action](payload.data)
+        let result = false
+
+        try {
+          result = model[LISTENERS][payload.action](payload.data)
+        } catch (e) {
+          if (this[LIFECYCLE].error) {
+            this[LIFECYCLE].error(
+              e,
+              payload.action.toString(),
+              payload.data,
+              this[STATE_CONTAINER]
+            )
+          } else {
+            throw e
+          }
+        }
+
         if (result !== false && this[SET_STATE] === false) {
           this.emitChange()
         }

--- a/test/failed-dispatch-test.js
+++ b/test/failed-dispatch-test.js
@@ -1,0 +1,95 @@
+import { assert } from 'chai'
+import Alt from '../dist/alt-with-runtime'
+import sinon from 'sinon'
+
+export default {
+  'catch failed dispatches': {
+    'uncaught dispatches result in an error'() {
+      const alt = new Alt()
+      const actions = alt.generateActions('fire')
+
+      class Uncaught {
+        constructor() {
+          this.bindListeners({ fire: actions.FIRE })
+        }
+
+        fire() {
+          throw new Error('oops')
+        }
+      }
+
+      const uncaught = alt.createStore(Uncaught)
+
+      assert.throws(() => actions.fire())
+    },
+
+    'errors can be caught though'() {
+      const alt = new Alt()
+      const actions = alt.generateActions('fire')
+
+      class Caught {
+        constructor() {
+          this.x = 0
+          this.bindListeners({ fire: actions.FIRE })
+
+          this.on('error', () => {
+            this.x = 1
+          })
+        }
+
+        fire() {
+          throw new Error('oops')
+        }
+      }
+
+      const caught = alt.createStore(Caught)
+
+      const storeListener = sinon.spy()
+
+      caught.listen(storeListener)
+
+      assert(caught.getState().x === 0)
+      assert.doesNotThrow(() => actions.fire())
+      assert(caught.getState().x === 1)
+
+      assert.notOk(storeListener.calledOnce, 'the store did not emit a change')
+
+      caught.unlisten(storeListener)
+    },
+
+    'you have to emit changes yourself'() {
+      const alt = new Alt()
+      const actions = alt.generateActions('fire')
+
+      class CaughtReturn {
+        constructor() {
+          this.x = 0
+          this.bindListeners({ fire: actions.FIRE })
+
+          this.on('error', () => {
+            this.x = 1
+            this.emitChange()
+          })
+        }
+
+        fire() {
+          throw new Error('oops')
+        }
+      }
+
+      const caughtReturn = alt.createStore(CaughtReturn)
+
+      const storeListener = sinon.spy()
+
+      caughtReturn.listen(storeListener)
+
+      assert(caughtReturn.getState().x === 0)
+      assert.doesNotThrow(() => actions.fire())
+      assert(caughtReturn.getState().x === 1)
+
+      assert.ok(storeListener.calledOnce)
+
+      caughtReturn.unlisten(storeListener)
+    },
+  }
+}


### PR DESCRIPTION
This adds a try/catch to alt's dispatch for purposes of allowing you to catch errors in the store.

If your store class contains a `failedDispatch` method you'll receive the error and then you can deal with it.

This opens the door for better rollbacks/atomic transactions.

If the store does not contain a failedDispatch method then the error throws so it is not swallowed.

Adds ~11 LOC to alt core.

My only concern is that now every dispatch call is wrapped in a try/catch.

Thoughts?