### PR TITLE
Atomic transactions

### DIFF
--- a/dist/alt-browser-with-addons.js
+++ b/dist/alt-browser-with-addons.js
@@ -1076,7 +1076,18 @@ var AltStore = (function () {
         model.beforeEach(payload.action.toString(), payload.data, _this8[STATE_CONTAINER]);
       }
       if (model[LISTENERS][payload.action]) {
-        var result = model[LISTENERS][payload.action](payload.data);
+        var result = false;
+
+        try {
+          result = model[LISTENERS][payload.action](payload.data);
+        } catch (e) {
+          if (typeof model.failedDispatch === "function") {
+            result = !!model.failedDispatch(e, payload.action.toString(), payload.data, _this8[STATE_CONTAINER]);
+          } else {
+            throw e;
+          }
+        }
+
         if (result !== false) {
           _this8.emitChange();
         }

--- a/dist/alt-browser.js
+++ b/dist/alt-browser.js
@@ -820,7 +820,18 @@ var AltStore = (function () {
         model.beforeEach(payload.action.toString(), payload.data, _this8[STATE_CONTAINER]);
       }
       if (model[LISTENERS][payload.action]) {
-        var result = model[LISTENERS][payload.action](payload.data);
+        var result = false;
+
+        try {
+          result = model[LISTENERS][payload.action](payload.data);
+        } catch (e) {
+          if (typeof model.failedDispatch === "function") {
+            result = !!model.failedDispatch(e, payload.action.toString(), payload.data, _this8[STATE_CONTAINER]);
+          } else {
+            throw e;
+          }
+        }
+
         if (result !== false) {
           _this8.emitChange();
         }

--- a/dist/alt-with-runtime.js
+++ b/dist/alt-with-runtime.js
@@ -77,7 +77,18 @@ var AltStore = (function () {
         model.beforeEach(payload.action.toString(), payload.data, _this8[STATE_CONTAINER]);
       }
       if (model[LISTENERS][payload.action]) {
-        var result = model[LISTENERS][payload.action](payload.data);
+        var result = false;
+
+        try {
+          result = model[LISTENERS][payload.action](payload.data);
+        } catch (e) {
+          if (typeof model.failedDispatch === "function") {
+            result = !!model.failedDispatch(e, payload.action.toString(), payload.data, _this8[STATE_CONTAINER]);
+          } else {
+            throw e;
+          }
+        }
+
         if (result !== false) {
           _this8.emitChange();
         }

--- a/dist/alt.js
+++ b/dist/alt.js
@@ -89,7 +89,18 @@ var AltStore = (function () {
         model.beforeEach(payload.action.toString(), payload.data, _this8[STATE_CONTAINER]);
       }
       if (model[LISTENERS][payload.action]) {
-        var result = model[LISTENERS][payload.action](payload.data);
+        var result = false;
+
+        try {
+          result = model[LISTENERS][payload.action](payload.data);
+        } catch (e) {
+          if (typeof model.failedDispatch === "function") {
+            result = !!model.failedDispatch(e, payload.action.toString(), payload.data, _this8[STATE_CONTAINER]);
+          } else {
+            throw e;
+          }
+        }
+
         if (result !== false) {
           _this8.emitChange();
         }

--- a/src/alt.js
+++ b/src/alt.js
@@ -76,7 +76,23 @@ class AltStore {
         )
       }
       if (model[LISTENERS][payload.action]) {
-        const result = model[LISTENERS][payload.action](payload.data)
+        let result = false
+
+        try {
+          result = model[LISTENERS][payload.action](payload.data)
+        } catch (e) {
+          if (typeof model.failedDispatch === 'function') {
+            result = !!model.failedDispatch(
+              e,
+              payload.action.toString(),
+              payload.data,
+              this[STATE_CONTAINER]
+            )
+          } else {
+            throw e
+          }
+        }
+
         if (result !== false) {
           this.emitChange()
         }

--- a/test/atomic-transactions-test.js
+++ b/test/atomic-transactions-test.js
@@ -1,0 +1,66 @@
+import { assert } from 'chai'
+import Alt from '../dist/alt-with-runtime'
+import atomicTransactions from '../utils/atomicTransactions'
+
+const alt = new Alt()
+
+const atom = atomicTransactions(alt)
+
+const actions = alt.generateActions('fire')
+
+const store1 = alt.createStore(atom({
+  displayName: 'Store1',
+
+  bindListeners: {
+    fire: actions.fire
+  },
+
+  state: { x: 0 },
+
+  fire: function () {
+    this.state.x = this.state.x + 1
+  }
+}))
+
+const store2 = alt.createStore(atom({
+  displayName: 'Store2',
+
+  bindListeners: {
+    fire: actions.fire
+  },
+
+  state: { y: 0 },
+
+  fire: function () {
+    this.state.y = this.state.y + 1
+
+    if (this.state.y === 2) {
+      throw new Error('wtf')
+    }
+  }
+}))
+
+export default {
+  'atomicTransactions': {
+    'do not update stores if there is an error'() {
+
+      assert(store1.getState().x === 0)
+      assert(store2.getState().y === 0)
+
+      actions.fire()
+
+      assert(store1.getState().x === 1)
+      assert(store2.getState().y === 1)
+
+      actions.fire()
+
+      assert(store1.getState().x === 1)
+      assert(store2.getState().y === 1)
+
+      actions.fire()
+
+      assert(store1.getState().x === 1)
+      assert(store2.getState().y === 1)
+    }
+  }
+}

--- a/test/failed-dispatch-test.js
+++ b/test/failed-dispatch-test.js
@@ -1,0 +1,95 @@
+import { assert } from 'chai'
+import Alt from '../dist/alt-with-runtime'
+import sinon from 'sinon'
+
+export default {
+  'catch failed dispatches': {
+    'uncaught dispatches result in an error'() {
+      const alt = new Alt()
+      const actions = alt.generateActions('fire')
+
+      class Uncaught {
+        constructor() {
+          this.bindListeners({ fire: actions.FIRE })
+        }
+
+        fire() {
+          throw new Error('oops')
+        }
+      }
+
+      const uncaught = alt.createStore(Uncaught)
+
+      assert.throws(() => actions.fire())
+    },
+
+    'errors can be caught though'() {
+      const alt = new Alt()
+      const actions = alt.generateActions('fire')
+
+      class Caught {
+        constructor() {
+          this.x = 0
+          this.bindListeners({ fire: actions.FIRE })
+        }
+
+        fire() {
+          throw new Error('oops')
+        }
+
+        failedDispatch() {
+          this.x = 1
+        }
+      }
+
+      const caught = alt.createStore(Caught)
+
+      const storeListener = sinon.spy()
+
+      caught.listen(storeListener)
+
+      assert(caught.getState().x === 0)
+      assert.doesNotThrow(() => actions.fire())
+      assert(caught.getState().x === 1)
+
+      assert.notOk(storeListener.calledOnce, 'the store did not emit a change')
+
+      caught.unlisten(storeListener)
+    },
+
+    'if returning true then a change is emitted'() {
+      const alt = new Alt()
+      const actions = alt.generateActions('fire')
+
+      class CaughtReturn {
+        constructor() {
+          this.x = 0
+          this.bindListeners({ fire: actions.FIRE })
+        }
+
+        fire() {
+          throw new Error('oops')
+        }
+
+        failedDispatch() {
+          this.x = 1
+          return true
+        }
+      }
+
+      const caughtReturn = alt.createStore(CaughtReturn)
+
+      const storeListener = sinon.spy()
+
+      caughtReturn.listen(storeListener)
+
+      assert(caughtReturn.getState().x === 0)
+      assert.doesNotThrow(() => actions.fire())
+      assert(caughtReturn.getState().x === 1)
+
+      assert.ok(storeListener.calledOnce)
+
+      caughtReturn.unlisten(storeListener)
+    },
+  }
+}

--- a/utils/atomicTransactions.js
+++ b/utils/atomicTransactions.js
@@ -1,0 +1,19 @@
+var makeFinalStore = require('./makeFinalStore')
+
+function atomicTransactions(alt) {
+  var finalStore = makeFinalStore(alt)
+
+  finalStore.listen(function () {
+    alt.takeSnapshot()
+  })
+
+  return function (store) {
+    store.failedDispatch = function () {
+      alt.rollback()
+    }
+
+    return store
+  }
+}
+
+module.exports = atomicTransactions


### PR DESCRIPTION
This adds some initial atomic transactions util

It's pretty barebones in that it only supports POJOs. But it's a proof of concept.

This PR is rebased on top of: #142 