### PR TITLE
README: Added "function" to regular old JavaScript code

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ var locationStore = alt.createStore({
     country: 'US'
   },
 
-  onUpdateLocation(obj) {
+  onUpdateLocation: function(obj) {
     var { city, country } = obj
     this.city = city
     this.country = country


### PR DESCRIPTION
Added missing `function` keyword, since in its current form it only works with an ES6 transpiler.