### PR TITLE
Allow customizing your state property key

### DIFF
--- a/dist/alt-browser-with-addons.js
+++ b/dist/alt-browser-with-addons.js
@@ -1486,7 +1486,7 @@ function createStoreFromClass(alt, StoreModel, key) {
 
   var store = _applyConstructor(Store, argsForConstructor);
 
-  storeInstance = assign(new AltStore(alt.dispatcher, store, null, StoreModel), getInternalMethods(StoreModel, builtIns));
+  storeInstance = assign(new AltStore(alt.dispatcher, store, typeof alt._stateKey === "string" ? store[alt._stateKey] : null, StoreModel), getInternalMethods(StoreModel, builtIns));
 
   return storeInstance;
 }
@@ -1503,6 +1503,7 @@ var Alt = (function () {
     this.actions = {};
     this.stores = {};
     this[LAST_SNAPSHOT] = this[INIT_SNAPSHOT] = "{}";
+    this._stateKey = config.stateKey;
   }
 
   _createClass(Alt, {

--- a/dist/alt-browser.js
+++ b/dist/alt-browser.js
@@ -1201,7 +1201,7 @@ function createStoreFromClass(alt, StoreModel, key) {
 
   var store = _applyConstructor(Store, argsForConstructor);
 
-  storeInstance = assign(new AltStore(alt.dispatcher, store, null, StoreModel), getInternalMethods(StoreModel, builtIns));
+  storeInstance = assign(new AltStore(alt.dispatcher, store, typeof alt._stateKey === "string" ? store[alt._stateKey] : null, StoreModel), getInternalMethods(StoreModel, builtIns));
 
   return storeInstance;
 }
@@ -1218,6 +1218,7 @@ var Alt = (function () {
     this.actions = {};
     this.stores = {};
     this[LAST_SNAPSHOT] = this[INIT_SNAPSHOT] = "{}";
+    this._stateKey = config.stateKey;
   }
 
   _createClass(Alt, {

--- a/dist/alt-with-runtime.js
+++ b/dist/alt-with-runtime.js
@@ -453,7 +453,7 @@ function createStoreFromClass(alt, StoreModel, key) {
 
   var store = babelHelpers.applyConstructor(Store, argsForConstructor);
 
-  storeInstance = assign(new AltStore(alt.dispatcher, store, null, StoreModel), getInternalMethods(StoreModel, builtIns));
+  storeInstance = assign(new AltStore(alt.dispatcher, store, typeof alt._stateKey === "string" ? store[alt._stateKey] : null, StoreModel), getInternalMethods(StoreModel, builtIns));
 
   return storeInstance;
 }
@@ -469,6 +469,7 @@ var Alt = (function () {
     this.actions = {};
     this.stores = {};
     this[LAST_SNAPSHOT] = this[INIT_SNAPSHOT] = "{}";
+    this._stateKey = config.stateKey;
   }
 
   babelHelpers.createClass(Alt, {

--- a/dist/alt.js
+++ b/dist/alt.js
@@ -470,7 +470,7 @@ function createStoreFromClass(alt, StoreModel, key) {
 
   var store = _applyConstructor(Store, argsForConstructor);
 
-  storeInstance = assign(new AltStore(alt.dispatcher, store, null, StoreModel), getInternalMethods(StoreModel, builtIns));
+  storeInstance = assign(new AltStore(alt.dispatcher, store, typeof alt._stateKey === "string" ? store[alt._stateKey] : null, StoreModel), getInternalMethods(StoreModel, builtIns));
 
   return storeInstance;
 }
@@ -487,6 +487,7 @@ var Alt = (function () {
     this.actions = {};
     this.stores = {};
     this[LAST_SNAPSHOT] = this[INIT_SNAPSHOT] = "{}";
+    this._stateKey = config.stateKey;
   }
 
   _createClass(Alt, {

--- a/src/alt.js
+++ b/src/alt.js
@@ -445,7 +445,14 @@ function createStoreFromClass(alt, StoreModel, key, ...argsForConstructor) {
   const store = new Store(...argsForConstructor)
 
   storeInstance = assign(
-    new AltStore(alt.dispatcher, store, null, StoreModel),
+    new AltStore(
+      alt.dispatcher,
+      store,
+      typeof alt._stateKey === 'string'
+        ? store[alt._stateKey]
+        : null,
+      StoreModel
+    ),
     getInternalMethods(StoreModel, builtIns)
   )
 
@@ -460,6 +467,7 @@ class Alt {
     this.actions = {}
     this.stores = {}
     this[LAST_SNAPSHOT] = this[INIT_SNAPSHOT] = '{}'
+    this._stateKey = config.stateKey
   }
 
   dispatch(action, data) {

--- a/test/custom-state-key-test.js
+++ b/test/custom-state-key-test.js
@@ -1,0 +1,26 @@
+import { assert } from 'chai'
+import Alt from '../dist/alt-with-runtime'
+
+const alt = new Alt({
+  stateKey: 'state'
+})
+
+class Store {
+  static displayName: 'CustomStateKeyStore'
+
+  constructor() {
+    this.foo = 1
+    this.state = { yes: 2 }
+  }
+}
+
+const store = alt.createStore(Store)
+
+export default {
+  'Custom State Key': {
+    'setting a custom key for declaring state'() {
+      assert.isUndefined(store.getState().foo, 'foo is private')
+      assert.isDefined(store.getState().yes, 'yes is part of state')
+    },
+  }
+}


### PR DESCRIPTION
Lets have our :cake: and eat it too.

This PR adds a way out of #158 where we can get the best of both worlds. Through alt's config object you can specify a state key where your state will live:

```js
const alt = new Alt({ stateKey: 'bears' })

class Foo {
  static displayName: 'FooStore'

  constructor() {
    this.lookThisIsPrivate = 'yes it is'

    this.bears = {
      state1: 1,
      state2: 2
    }
  }
}
```