### PR TITLE
withAltContext as decorator

### DIFF
--- a/src/utils/withAltContext.js
+++ b/src/utils/withAltContext.js
@@ -1,17 +1,19 @@
 import React from 'react'
 
-export default function withAltContext(flux, Component) {
-  return React.createClass({
-    childContextTypes: {
-      flux: React.PropTypes.object
-    },
+export default function withAltContext(flux) {
+  return function (Component) {
+    return React.createClass({
+      childContextTypes: {
+        flux: React.PropTypes.object
+      },
 
-    getChildContext() {
-      return { flux }
-    },
+      getChildContext() {
+        return { flux }
+      },
 
-    render() {
-      return React.createElement(Component, this.props)
-    }
-  })
+      render() {
+        return React.createElement(Component, this.props)
+      }
+    })
+  }
 }

--- a/test/store-listener-component-test.js
+++ b/test/store-listener-component-test.js
@@ -119,7 +119,13 @@ export default {
     'works with context'() {
       const flux = new Flux()
 
-      const ContextComponent = withAltContext(flux, AltContainer)
+      @withAltContext(flux)
+      class ContextComponent extends React.Component {
+        render() {
+          return <AltContainer />
+        }
+      }
+
       const tree = TestUtils.renderIntoDocument(<ContextComponent />)
 
       const contextComponent = TestUtils.findRenderedComponentWithType(
@@ -149,7 +155,7 @@ export default {
         }
       })
 
-      const WrappedComponent = withAltContext(flux, TestComponent)
+      const WrappedComponent = withAltContext(flux)(TestComponent)
 
       const node = TestUtils.renderIntoDocument(<WrappedComponent />)
       const span = TestUtils.findRenderedDOMComponentWithTag(node, 'span')


### PR DESCRIPTION
This makes withAltContext a decorator.

New API:

```js
@withAltContext(flux);
class App extends React.Component {
  render() {
    return (
      // things in here get the flux context
    )
  }
}
```

or

```js
class App extends React.Component { }
module.exports = withAltContext(flux)(App)
```