### PR TITLE
export flux constructor so user does not need require it outside again

### DIFF
--- a/src/alt/index.js
+++ b/src/alt/index.js
@@ -220,4 +220,5 @@ class Alt {
   }
 }
 
+export { Dispatcher }
 export default Alt


### PR DESCRIPTION
I'm using `alt.js` to help me rewrite my existing code. However, I have used `flux` for other purposes in the existing code. So i'm wondering if I used the bundle version of `alt.js`, is it ok it also export the `flux` constructor?