### PR TITLE
Pass action details through the dispatch

### DIFF
--- a/src/alt/AltAction.js
+++ b/src/alt/AltAction.js
@@ -3,14 +3,15 @@ import * as Sym from './symbols/symbols'
 const { ACTION_HANDLER, ACTION_UID } = Sym
 
 export default class AltAction {
-  constructor(alt, name, action, actions) {
+  constructor(alt, name, action, actions, actionDetails) {
     this[ACTION_UID] = name
     this[ACTION_HANDLER] = action.bind(this)
+    this.actionDetails = actionDetails
     this.actions = actions
     this.alt = alt
   }
 
   dispatch(data) {
-    this.alt.dispatch(this[ACTION_UID], data)
+    this.alt.dispatch(this[ACTION_UID], data, this.actionDetails)
   }
 }

--- a/src/alt/index.js
+++ b/src/alt/index.js
@@ -43,8 +43,8 @@ class Alt {
     this[LAST_SNAPSHOT] = {}
   }
 
-  dispatch(action, data) {
-    this.dispatcher.dispatch({ action, data })
+  dispatch(action, data, details) {
+    this.dispatcher.dispatch({ action, data, details })
   }
 
   createUnsavedStore(StoreModel, ...args) {

--- a/src/alt/utils/makeAction.js
+++ b/src/alt/utils/makeAction.js
@@ -11,8 +11,15 @@ export default function makeAction(alt, namespace, name, implementation, obj) {
   alt[ACTIONS_REGISTRY][actionId] = 1
   const actionSymbol = Symbol.for(`alt/${actionId}`)
 
+  const data = {
+    namespace,
+    name,
+    id: actionId,
+    symbol: actionSymbol
+  }
+
   // Wrap the action so we can provide a dispatch method
-  const newAction = new AltAction(alt, actionSymbol, implementation, obj)
+  const newAction = new AltAction(alt, actionSymbol, implementation, obj, data)
 
   // the action itself
   const action = newAction[ACTION_HANDLER]
@@ -22,6 +29,7 @@ export default function makeAction(alt, namespace, name, implementation, obj) {
     })
   }
   action[ACTION_KEY] = actionSymbol
+  action.data = data
 
   // ensure each reference is unique in the namespace
   const container = alt.actions[namespace]

--- a/src/utils/ActionListeners.js
+++ b/src/utils/ActionListeners.js
@@ -33,7 +33,7 @@ ActionListeners.prototype.addActionListener = function (symAction, handler) {
   const id = this.dispatcher.register((payload) => {
     /* istanbul ignore else */
     if (symAction === payload.action) {
-      handler(payload.data)
+      handler(payload.data, payload.details)
     }
   })
   this[ALT_LISTENERS][id] = true

--- a/test/listen-to-actions.js
+++ b/test/listen-to-actions.js
@@ -6,6 +6,8 @@ import ActionListeners from '../utils/ActionListeners'
 const alt = new Alt()
 
 class MyActions {
+  static displayName = 'ActionListenerActions'
+
   constructor() {
     this.generateActions('updateName')
   }
@@ -17,8 +19,10 @@ const listener = new ActionListeners(alt)
 
 export default {
   'listen to actions globally'() {
-    const id = listener.addActionListener(myActions.UPDATE_NAME, (name) => {
+    const id = listener.addActionListener(myActions.UPDATE_NAME, (name, details) => {
       assert(name === 'yes', 'proper data was passed in')
+      assert(details.namespace === 'ActionListenerActions')
+      assert(details.name === 'updateName')
     })
 
     assert.isString(id, 'the dispatcher id is returned for the listener')


### PR DESCRIPTION
Fixes #192 we pass in a whole slew of details through the dispatch.

For this action class:

```js
class MyActions {
  static displayName = 'MyActions'

  updateName(name) { this.dispatch(name) }
}
```

we would get this info:

```js
details: {
  namespace: 'MyActions',
  name: 'updateName',
  id: 'MyActions.updateName',
  symbol: Symbol('alt/MyActions.updateName')
}
```

you can extra it via `payload.details`.