### PR TITLE
Improve consistency of action import on example

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,7 +22,6 @@
     // possible errors
     "comma-dangle": [2, "never"],
     "no-cond-assign": [2, "always"],
-    "no-console": 1,
     "no-debugger": 1,
     "no-alert": 1,
     "no-constant-condition": 1,
@@ -128,6 +127,7 @@
       "spaced-line-comment": 2,
 
     /* custom rules */
+    "no-console": 0,
     "space-before-function-paren": [2, {
       "named": "never",
       "anonymous": "always"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ after_script: cat ./coverage/lcov.info | coveralls
 node_js:
   - "0.10"
   - "0.12"
-  - iojs
+  - iojs-v1.8.1

--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ Store
 
 ```js
 import alt from './alt';
-import TodoActions from './TodoActions'
+import todoActions from './TodoActions'
 
 class TodoStore {
   constructor() {
     this.bindListeners({
-      updateTodo: TodoActions.updateTodo
+      updateTodo: todoActions.updateTodo
     });
 
     this.todos = {};

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 * Isomorphic and works with react-native.
 * Actively maintained and being used in production.
 * Extremely [flexible](#flexibility) and unopinionated in how you use flux. Create traditional singletons or use dependency injection.
-* It is [terse](https://github.com/goatslacker/alt#flux-minus-the-boilerplate). No boilerplate.
+* It is terse. No boilerplate.
 
 ### What does it look like?
 
@@ -70,7 +70,29 @@ class TodoStore {
 export default alt.createStore(TodoStore, 'TodoStore');
 ```
 
-## Principles of Flux
+## In the Wild
+
+### Examples
+
+* [Airbnb Airpal](https://github.com/airbnb/airpal/tree/master/src/main/resources/assets)
+* [Alt Notify](https://github.com/sourcescript/alt-notify)
+* [Chrome Devtool](https://github.com/goatslacker/alt-devtool)
+* [Example Tests](https://github.com/jdlehman/alt-example-tests)
+* [Github Example](https://github.com/RookieOne/react-alt-github-example)
+* [Isomorphic Alt](https://github.com/patrickkim/iso-alt)
+* [React Router Example](https://github.com/lostpebble/alt-react-router-example)
+* [React Router Loopback](https://github.com/bkniffler/react-router-alt-loopback)
+* [React Weather](https://github.com/sapegin/react-weather)
+* [Shopping Cart](https://github.com/voronianski/flux-comparison/tree/master/alt)
+* [Todo](https://github.com/benstokoe/alt-todo)
+* [Typeahead](https://github.com/timtyrrell/alt-typeahead)
+
+### Boilerplates
+
+* [Isomorphic Flux Boilerplate](https://github.com/iam4x/isomorphic-flux-boilerplate)
+* [React + Webpack + Node](https://github.com/choonkending/react-webpack-node)
+
+## Pure Flux + More
 
 * Unidirectional data flow
 * Stores have no setters
@@ -78,24 +100,7 @@ export default alt.createStore(TodoStore, 'TodoStore');
 * Single central dispatcher
 * All Stores receive the dispatch
 
-Read more about the [Principles of Flux](https://medium.com/@goatslacker/principles-of-flux-ea872bc20772).
-
-## Flux minus the boilerplate
-
-* No [JS "constants"](https://github.com/facebook/flux/blob/master/examples/flux-chat/js/constants/ChatConstants.js).
-* No [static string tossing](https://github.com/facebook/flux/blob/master/examples/flux-chat/js/dispatcher/ChatAppDispatcher.js#L39).
-* No [massive switch statements](https://github.com/facebook/flux/blob/master/examples/flux-chat/js/stores/MessageStore.js#L111).
-
-There is no giant switch statement you have to write in your store and this is because alt removes the burden of constants from the developer.
-This has the wonderful side effect of making the custom dispatcher logic unnecessary, thus removing the dispatcher from the equation.
-
-Make no mistake, there is still a single dispatcher through which actions flow on their merry way to the store, in fact, you still get the benefit of being able to hook into the dispatcher to listen to all the global events for debugging, fun, or misery.
-The dispatcher is just a part of alt and something you don't necessarily have to write custom code for.
-
-These removals make the code terse and easy to follow, there is less indirection and the learning curve to grok is much lower.
-Think I'm lying? [Check out an example](#differences-example).
-
-## Flux enhanced
+Read about the [Principles of Flux](https://medium.com/@goatslacker/principles-of-flux-ea872bc20772).
 
 One really cool aspect of alt is that you can save snapshots of the entire application's state at any given point in time.
 This has many different use cases like:
@@ -107,12 +112,16 @@ This has many different use cases like:
 
 There are also many [utils](/src/utils) available which interface well with alt:
 
-* [DispatchRecorder](/src/utils/DispatcherRecorder.js) lets you record all your dispatches and replay them back at a later time.
-* [FinalStore](/src/utils/makeFinalStore.js) is a Store that you can listen to that only emits when all your other stores have received all their data.
-* [IsomorphicRenderer](/src/utils/IsomorphicRenderer.js) a function that wraps your component to be isomorphic ready.
 * [ActionListener](/src/utils/ActionListeners.js) lets you listen to individual actions without having to create a store.
-
-Last but not least, alt is meant to work with ES6. That is we're betting you'll be writing your stores and actions as classes. This part isn't necessary but you really should write some ES6 anyways because it's nice.
+* [AltContainer](/components/AltContainer.js) a higher-order container component that is your swiss army knife for React.
+* [atomic](/src/utils/atomic.js) enables your stores for atomic transactions.
+* [connectToStores](/src/utils/connectToStores.js) a higher-order function that wraps your React components for store listening.
+* [decorators](/src/utils/decorators.js) a collection of useful ES7 decorators for working with alt.
+* [DispatchRecorder](/src/utils/DispatcherRecorder.js) lets you record all your dispatches and replay them back at a later time.
+* [ImmutableUtil](/src/utils/ImmutableUtil.js) makes working with immutable-js easy.
+* [IsomorphicRenderer](/src/utils/IsomorphicRenderer.js) a function that wraps your component to be isomorphic ready.
+* [TimeTravel](/src/utils/TimeTravel.js) enhances your stores so they are able to travel through different states in time.
+* [FinalStore](/src/utils/makeFinalStore.js) is a Store that you can listen to that only emits when all your other stores have received all their data.
 
 ## Topical Guide
 

--- a/dist/alt-with-addons.js
+++ b/dist/alt-with-addons.js
@@ -1747,16 +1747,18 @@ var _Symbol2 = _interopRequireWildcard(_Symbol);
 var _ACTION_KEY$ALL_LISTENERS$LIFECYCLE$LISTENERS$PUBLIC_METHODS = require('../symbols/symbols');
 
 var StoreMixinEssentials = {
-  waitFor: function waitFor(sources) {
-    if (!sources) {
+  waitFor: function waitFor() {
+    for (var _len = arguments.length, sources = Array(_len), _key = 0; _key < _len; _key++) {
+      sources[_key] = arguments[_key];
+    }
+
+    if (!sources.length) {
       throw new ReferenceError('Dispatch tokens not provided');
     }
 
     var sourcesArray = sources;
-    if (arguments.length === 1) {
-      sourcesArray = Array.isArray(sourcesArray) ? sourcesArray : [sourcesArray];
-    } else {
-      sourcesArray = Array.prototype.slice.call(arguments);
+    if (sources.length === 1) {
+      sourcesArray = Array.isArray(sources[0]) ? sources[0] : sources;
     }
 
     var tokens = sourcesArray.map(function (source) {

--- a/dist/alt.js
+++ b/dist/alt.js
@@ -1114,16 +1114,18 @@ var _Symbol2 = _interopRequireWildcard(_Symbol);
 var _ACTION_KEY$ALL_LISTENERS$LIFECYCLE$LISTENERS$PUBLIC_METHODS = require('../symbols/symbols');
 
 var StoreMixinEssentials = {
-  waitFor: function waitFor(sources) {
-    if (!sources) {
+  waitFor: function waitFor() {
+    for (var _len = arguments.length, sources = Array(_len), _key = 0; _key < _len; _key++) {
+      sources[_key] = arguments[_key];
+    }
+
+    if (!sources.length) {
       throw new ReferenceError('Dispatch tokens not provided');
     }
 
     var sourcesArray = sources;
-    if (arguments.length === 1) {
-      sourcesArray = Array.isArray(sourcesArray) ? sourcesArray : [sourcesArray];
-    } else {
-      sourcesArray = Array.prototype.slice.call(arguments);
+    if (sources.length === 1) {
+      sourcesArray = Array.isArray(sources[0]) ? sources[0] : sources;
     }
 
     var tokens = sourcesArray.map(function (source) {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "object-assign": "^2.0.0"
   },
   "devDependencies": {
-    "babel": "^5.1.11",
-    "babel-core": "^5.1.11",
+    "babel": "^5.2.13",
+    "babel-core": "^5.2.13",
     "babelify": "^6.0.2",
     "browserify": "^9.0.3",
     "browserify-shim": "^3.8.5",
@@ -45,7 +45,7 @@
     "build-alt-browser": "browserify src/alt -t [envify --NODE_ENV production ] -t babelify --outfile dist/alt.js --standalone Alt",
     "build-alt-browser-with-addons": "browserify src/alt/addons.js -t [envify --NODE_ENV production ] -t babelify -t browserify-shim --outfile dist/alt-with-addons.js --standalone Alt",
     "build-test": "babel src/alt --out-dir lib -r --stage 0 && babel src/utils --out-dir utils -r --stage 0",
-    "coverage": "npm run build-test && istanbul cover node_modules/mocha/bin/_mocha -- -u exports -R spec --require ./test/babel --require babel-core/external-helpers test",
+    "coverage": "npm run build-test && istanbul cover node_modules/mocha/bin/_mocha -- -u exports -R spec --require ./test/babel test",
     "clean": "rimraf lib && rimraf utils",
     "lint": "eslint src components",
     "posttest": "npm run build-alt",
@@ -53,7 +53,7 @@
     "pretest": "npm run clean && npm run build-test",
     "test": "npm run tests-node",
     "test-browser": "browserify test/browser/index.js -t babelify --outfile test/browser/tests.js",
-    "tests-node": "mocha -u exports -R spec --require ./test/babel --require babel-core/external-helpers test"
+    "tests-node": "mocha -u exports -R spec --require ./test/babel test"
   },
   "browserify-shim": {
     "react": "global:React",

--- a/src/alt/utils/StoreMixins.js
+++ b/src/alt/utils/StoreMixins.js
@@ -8,19 +8,17 @@ import {
 } from '../symbols/symbols'
 
 export const StoreMixinEssentials = {
-  waitFor(sources) {
-    if (!sources) {
+  waitFor(...sources) {
+    if (!sources.length) {
       throw new ReferenceError('Dispatch tokens not provided')
     }
 
     let sourcesArray = sources
-    if (arguments.length === 1) {
-      sourcesArray = Array.isArray(sourcesArray) ? sourcesArray : [sourcesArray]
-    } else {
-      sourcesArray = Array.prototype.slice.call(arguments)
+    if (sources.length === 1) {
+      sourcesArray = Array.isArray(sources[0]) ? sources[0] : sources
     }
 
-    let tokens = sourcesArray.map((source) => {
+    const tokens = sourcesArray.map((source) => {
       return source.dispatchToken || source
     })
 

--- a/test/babel/index.js
+++ b/test/babel/index.js
@@ -1,3 +1,4 @@
+require('babel-core/external-helpers')
 require('babel/register')({
   stage: 0
 })

--- a/test/babel/index.js
+++ b/test/babel/index.js
@@ -1,4 +1,4 @@
 require('babel-core/external-helpers')
-require('babel/register')({
+require('babel/register-without-polyfill')({
   stage: 0
 })

--- a/test/helpers/ReactComponent.js
+++ b/test/helpers/ReactComponent.js
@@ -1,3 +1,5 @@
+import assign from 'object-assign'
+
 class ReactComponent {
   setState(state) {
     this.state = state
@@ -52,7 +54,7 @@ class ReactComponent {
       let defaultProps = component.getDefaultProps
         ? component.getDefaultProps()
         : {}
-      component.props = Object.assign({}, defaultProps, props)
+      component.props = assign({}, defaultProps, props)
 
       component.state = component.getInitialState
         ? component.getInitialState()

--- a/test/index.js
+++ b/test/index.js
@@ -501,11 +501,11 @@ const tests = {
   'specifying stores to snapshot'() {
     const snapshot = alt.takeSnapshot('MyStore', 'AltSecondStore')
     assert.deepEqual(Object.keys(JSON.parse(snapshot)), ['MyStore', 'AltSecondStore'], 'the snapshot includes specified stores')
-    assert.isFalse(Object.keys(JSON.parse(snapshot)).includes('LifeCycleStore'), 'the snapshot does not include unspecified stores')
+    assert(Object.keys(JSON.parse(snapshot)).indexOf('LifeCycleStore') === -1, 'the snapshot does not include unspecified stores')
 
     const snapshot2 = alt.takeSnapshot(myStore, secondStore)
     assert.deepEqual(Object.keys(JSON.parse(snapshot2)), ['MyStore', 'AltSecondStore'], 'the snapshot includes specified stores')
-    assert.isFalse(Object.keys(JSON.parse(snapshot2)).includes('LifeCycleStore'), 'the snapshot does not include unspecified stores')
+    assert(Object.keys(JSON.parse(snapshot2)).indexOf('LifeCycleStore') === -1, 'the snapshot does not include unspecified stores')
   },
 
   'serializing/deserializing snapshot/bootstrap data'(){


### PR DESCRIPTION
From line 171 onwards, all Stores and Actions classes start with uppercase and all **created** actions and stores start with lowercase:

```
var locationActions = alt.createActions(LocationActions)
```

Therefore, in the first and foremost example, when we `export default alt.createActions(TodoActions);`, we should probably import it into a lowercase var.

Opinions on this?