### PR TITLE
decorators for instances

### DIFF
--- a/test/decorators-test.js
+++ b/test/decorators-test.js
@@ -1,6 +1,13 @@
 import { assert } from 'chai'
 import Alt from '../'
-import { createActions, createStore, bind, expose } from '../utils/decorators'
+import {
+  createActions,
+  createStore,
+  bind,
+  expose,
+  bindWithContext,
+  decorate
+} from '../utils/decorators'
 
 const alt = new Alt()
 
@@ -55,8 +62,8 @@ export default {
     'decorating action listening and public methods'() {
       const TodoActions = alt.generateActions('addTodo')
 
-      @createStore(alt)
-      class TodoStore {
+      @decorate(alt)
+      class TodoStoreClass {
         static displayName = 'TodoStore'
 
         constructor() {
@@ -79,11 +86,42 @@ export default {
         }
       }
 
+      const TodoStore = alt.createStore(TodoStoreClass)
+
       TodoActions.addTodo('hello')
 
       assert(TodoStore.getState().id === 1)
       assert.isFunction(TodoStore.getTodo)
       assert(TodoStore.getTodo(0) === 'hello')
+    },
+
+    'decorating instances using context'() {
+      class TodoStore {
+        constructor() {
+          this.todos = []
+        }
+
+        @bindWithContext(alt => alt.actions.TodoActions.addTodo)
+        addTodo(item) {
+          this.todos.push(item)
+        }
+      }
+
+      class Flux extends Alt {
+        constructor() {
+          super()
+          this.addActions('TodoActions', [
+            'addTodo'
+          ])
+          this.addStore('TodoStore', decorate(this)(TodoStore))
+        }
+      }
+
+      const flux = new Flux()
+      assert(flux.stores.TodoStore.getState().todos.length === 0, 'state is empty')
+      flux.actions.TodoActions.addTodo('hello world')
+      assert(flux.stores.TodoStore.getState().todos.length === 1, 'we have an item')
+      assert(flux.stores.TodoStore.getState().todos[0] === 'hello world', 'it is hello world')
     },
   }
 }


### PR DESCRIPTION
Fixes #244 

API:

```js
      class TodoStore {
        constructor() {
          this.todos = []
        }

        @bindWithContext(alt => alt.actions.TodoActions.addTodo)
        addTodo(item) {
          this.todos.push(item)
        }
      }

      class Flux extends Alt {
        constructor() {
          super()
          this.addActions('TodoActions', [
            'addTodo'
          ])
          this.addStore('TodoStore', decorate(this)(TodoStore))
        }
      }
```
