### PR TITLE
added helpful warnings for Flux instance methods 

### DIFF
--- a/src/alt/index.js
+++ b/src/alt/index.js
@@ -185,20 +185,48 @@ class Alt {
   // Instance type methods for injecting alt into your application as context
 
   addActions(name, ActionsClass, ...args) {
+    if (typeof name !== 'string') utils.warn(`actions must have name`)
+
+    if (Object.is(ActionsClass, undefined) ||
+        Object.is(ActionsClass, null)) {
+      utils.warn(`${name} must be an Array or an ActionsClass`)
+    }
+
     this.actions[name] = Array.isArray(ActionsClass)
       ? this.generateActions.apply(this, ActionsClass)
       : this.createActions(ActionsClass, ...args)
   }
 
   addStore(name, StoreModel, ...args) {
+    if (typeof name !== 'string') utils.warn(`store must have name`)
+
+    if (Object.is(StoreModel, undefined) ||
+        Object.is(StoreModel, null)) {
+      utils.warn(`${name} must be a StoreModel`)
+    }
+
     this.createStore(StoreModel, name, ...args)
   }
 
   getActions(name) {
+    if (!this.actions[name]) {
+      utils.warn(
+        `"${name}" not found. available actions are:
+         ${Object.keys(this.actions).join(', ')}`
+      )
+    }
+
     return this.actions[name]
   }
 
   getStore(name) {
+    if (!this.stores[name]) {
+      utils.warn(
+        `"${name}" not found. available stores are:
+         ${Object.keys(this.stores).join(', ')}`
+      )
+    }
+
     return this.stores[name]
   }
 }


### PR DESCRIPTION
if will warn in those cases:

this.addActions('fooActions', null);
this.addActions('fooActions', undefined);
=>  fooActions must be an Array or an ActionsClass

this.addStore('fooStore', null);
this.addStore('fooStore', undefined);
=>  fooStore must be a StoreModel

this.addActions(FooActions);
=> actions must have name

this.addStore(FooStore);
=> store must have name

getStore('fooStore')
=> "fooStore" not found. available stores are: productStore, cartStore

getActions('fooActions')
=> "fooActions" not found. available actions are: productActions, cartActions

also added console.trace() to utils.warn() to print a call stack