### PR TITLE
Allow shouldFetch function in data source for async calls

### DIFF
--- a/dist/alt-with-addons.js
+++ b/dist/alt-with-addons.js
@@ -1546,9 +1546,10 @@ var StoreMixin = {
 
         var state = _this.getInstance().getState();
         var value = asyncSpec.local && asyncSpec.local.apply(asyncSpec, [state].concat(args));
+        var shouldFetch = asyncSpec.shouldFetch ? asyncSpec.shouldFetch.apply(asyncSpec, [state].concat(args)) : !value;
 
         // if we don't have it in cache then fetch it
-        if (!value) {
+        if (shouldFetch) {
           _isLoading = true;
           _hasError = false;
           /* istanbul ignore else */

--- a/dist/alt.js
+++ b/dist/alt.js
@@ -975,9 +975,10 @@ var StoreMixin = {
 
         var state = _this.getInstance().getState();
         var value = asyncSpec.local && asyncSpec.local.apply(asyncSpec, [state].concat(args));
+        var shouldFetch = asyncSpec.shouldFetch ? asyncSpec.shouldFetch.apply(asyncSpec, [state].concat(args)) : !value;
 
         // if we don't have it in cache then fetch it
-        if (!value) {
+        if (shouldFetch) {
           _isLoading = true;
           _hasError = false;
           /* istanbul ignore else */

--- a/docs/async.md
+++ b/docs/async.md
@@ -35,7 +35,12 @@ const SearchSource = {
       // here we setup some actions to handle our response
       loading: SearchActions.loadingResults,
       success: SearchActions.receivedResults,
-      error: SearchActions.fetchingResultsFailed
+      error: SearchActions.fetchingResultsFailed,
+
+      // should fetch has precedence over the value returned by local in determining whether remote should be called
+      shouldFetch(state) {
+        return true
+      }
     };
   }
 };
@@ -87,6 +92,10 @@ remote(state, one, two, three) {
 
 SearchStore.performSearch(1, 2, 3);
 ```
+
+### shouldFetch(state: object, ...args: any)
+
+This function determines whether or not remote needs to be called, despite the value returned by `local`. If `shouldFetch` returns true, it will always get the data from `remote` and if it returns false, it will always use the value from `local`.
 
 ### loading
 

--- a/src/alt/store/StoreMixin.js
+++ b/src/alt/store/StoreMixin.js
@@ -38,9 +38,10 @@ const StoreMixin = {
       publicMethods[methodName] = (...args) => {
         const state = this.getInstance().getState()
         const value = asyncSpec.local && asyncSpec.local(state, ...args)
+        const shouldFetch = asyncSpec.shouldFetch ? asyncSpec.shouldFetch(state, ...args) : !value
 
         // if we don't have it in cache then fetch it
-        if (!value) {
+        if (shouldFetch) {
           isLoading = true
           hasError = false
           /* istanbul ignore else */

--- a/test/async-test.js
+++ b/test/async-test.js
@@ -38,6 +38,26 @@ const StargazerSource = {
       success: StargazerActions.usersReceived,
       error: StargazerActions.failed
     }
+  },
+  alwaysFetchUsers() {
+    return {
+      remote,
+      local: () => true,
+      loading: StargazerActions.fetchingUsers,
+      success: StargazerActions.usersReceived,
+      error: StargazerActions.failed,
+      shouldFetch: () => true
+    }
+  },
+  neverFetchUsers() {
+    return {
+      remote,
+      local: () => false,
+      loading: StargazerActions.fetchingUsers,
+      success: StargazerActions.usersReceived,
+      error: StargazerActions.failed,
+      shouldFetch: () => false
+    }
   }
 }
 
@@ -177,6 +197,18 @@ export default {
 
       StargazerStore.fetchUsers('alts')
       assert.ok(StargazerStore.isLoading())
+    },
+
+    'shouldFetch is true'() {
+      StargazerStore.alwaysFetchUsers()
+      assert.ok(StargazerStore.isLoading())
+      assert.ok(remote.calledOnce)
+    },
+
+    'shouldFetch is false'() {
+      StargazerStore.neverFetchUsers()
+      assert.notOk(StargazerStore.isLoading())
+      assert(remote.callCount === 0)
     },
   }
 }


### PR DESCRIPTION
If shouldFetch returns true, it will always call remote to get the value, and if it returns false, it will always use the local value. If it is not defined, the presence of the local value determines if remote is called or not.

#257 