### PR TITLE
Fix recycling values that are not set

### DIFF
--- a/src/alt/utils/StateFunctions.js
+++ b/src/alt/utils/StateFunctions.js
@@ -7,10 +7,10 @@ export function setAppState(instance, data, onStore) {
     const store = instance.stores[key]
     if (store) {
       const { config } = store.StoreModel
-      if (config.onDeserialize) {
-        obj[key] = config.onDeserialize(value) || value
-      }
-      fn.assign(store[Sym.STATE_CONTAINER], obj[key])
+      const state = store[Sym.STATE_CONTAINER]
+      if (config.onDeserialize) obj[key] = config.onDeserialize(value) || value
+      fn.eachObject(k => delete state[k], [state])
+      fn.assign(state, obj[key])
       onStore(store)
     }
   }, [obj])

--- a/test/recycle-test.js
+++ b/test/recycle-test.js
@@ -1,0 +1,29 @@
+import { assert } from 'chai'
+import Alt from '../'
+import sinon from 'sinon'
+
+export default {
+  'Recycling': {
+    'recycles a store with no initial state'() {
+      const alt = new Alt()
+      const actions = alt.generateActions('fire')
+
+      const store = alt.createStore(function () {
+        this.bindAction(actions.fire, () => {
+          this.test = (this.test || 0) + 1
+        })
+      }, 'Store')
+
+
+      assert(Object.keys(store.getState()).length === 0, 'store has no state')
+      actions.fire()
+
+      assert(store.getState().test === 1, 'store has some state')
+
+      alt.recycle()
+
+      assert(Object.keys(store.getState()).length === 0, 'store was emptied')
+      assert.isUndefined(store.getState().test, 'store was recycled to initial state')
+    },
+  }
+}


### PR DESCRIPTION
This fixes a bug where recycle used to merge state so if the keys were not being overwritten then some old state would remain.

This affected rollbacks, recycle, and bootstrap.