### PR TITLE
Fix isLoading for multiple async calls

### DIFF
--- a/docs/async.md
+++ b/docs/async.md
@@ -58,7 +58,7 @@ class SearchStore {
 }
 ```
 
-Now we'll have a few methods available for use: `SearchStore.performSearch()`, `SearchStore.isLoading()`, and `SearchStore.hasError()`.
+Now we'll have a few methods available for use: `SearchStore.performSearch()`, and `SearchStore.isLoading()`.
 
 ## API
 


### PR DESCRIPTION
Fixes isLoading call if multiple requests are in-flight.

Given the nature that the status is reset every time a new call is made a situation may arise where the isLoading boolean is prematurely set to false. Changing this to a counter fixes the issue.

cc @wlue