### PR TITLE
Update link to API Reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ There are also many [utils](/src/utils) available which interface well with alt:
 
 ## Topical Guide
 
-Check out the [API Reference](https://goatslacker.github.io/alt/) for full in-depth docs.
+Check out the [API Reference](http://alt.js.org/docs/) for full in-depth docs.
 
 First we install alt through npm. Although alt is also available through bower.
 


### PR DESCRIPTION
**What**
I updated the link to API reference from [https://goatslacker.github.io/alt/](https://goatslacker.github.io/alt/) to [http://alt.js.org/docs/](http://alt.js.org/docs/)

**Why**
The current address links to the site with broken styles (tested on Linux with FF 38 and Chromium 43 with and without extensions) - it seems that's the same page as [the official one](http://alt.js.org/) but without any styles (maybe that's the problem on my end?). But I guess it's also good to have consistent URLs in the project.

**Post Scriptum**
I love `alt` :)