### PR TITLE
Add debug to alt

### DIFF
--- a/dist/alt-with-addons.js
+++ b/dist/alt-with-addons.js
@@ -1068,6 +1068,7 @@ function makeAction(alt, namespace, name, implementation, obj) {
 module.exports = exports['default'];
 
 },{"../symbols/symbols":15,"../utils/AltUtils":16,"es-symbol":5}],11:[function(require,module,exports){
+/*global window*/
 'use strict';
 
 Object.defineProperty(exports, '__esModule', {
@@ -1352,6 +1353,16 @@ var Alt = (function () {
     key: 'getStore',
     value: function getStore(name) {
       return this.stores[name];
+    }
+  }], [{
+    key: 'debug',
+    value: function debug(name, alt) {
+      var key = 'alt.js.org';
+      if (typeof window !== 'undefined') {
+        window[key] = window[key] || [];
+        window[key].push({ name: name, alt: alt });
+      }
+      return alt;
     }
   }]);
 

--- a/dist/alt.js
+++ b/dist/alt.js
@@ -1508,6 +1508,7 @@ function assign(target) {
 }
 
 },{}],14:[function(require,module,exports){
+/*global window*/
 'use strict';
 
 Object.defineProperty(exports, '__esModule', {
@@ -1792,6 +1793,16 @@ var Alt = (function () {
     key: 'getStore',
     value: function getStore(name) {
       return this.stores[name];
+    }
+  }], [{
+    key: 'debug',
+    value: function debug(name, alt) {
+      var key = 'alt.js.org';
+      if (typeof window !== 'undefined') {
+        window[key] = window[key] || [];
+        window[key].push({ name: name, alt: alt });
+      }
+      return alt;
     }
   }]);
 

--- a/src/alt/index.js
+++ b/src/alt/index.js
@@ -1,3 +1,4 @@
+/*global window*/
 import { Dispatcher } from 'flux'
 
 import * as StateFunctions from './utils/StateFunctions'
@@ -200,6 +201,15 @@ class Alt {
 
   getStore(name) {
     return this.stores[name]
+  }
+
+  static debug(name, alt) {
+    const key = 'alt.js.org'
+    if (typeof window !== 'undefined') {
+      window[key] = window[key] || []
+      window[key].push({ name, alt })
+    }
+    return alt
   }
 }
 

--- a/test/debug-alt-test.js
+++ b/test/debug-alt-test.js
@@ -1,0 +1,31 @@
+import Alt from '../'
+import { assert } from 'chai'
+
+export default {
+  'debug mode': {
+    beforeEach() {
+      global.window = {}
+    },
+
+    'enable debug mode'() {
+      const alt = new Alt()
+      Alt.debug('an identifier', alt)
+
+      assert.isArray(global.window['alt.js.org'])
+      assert(global.window['alt.js.org'].length === 1)
+      assert.isString(global.window['alt.js.org'][0].name)
+      assert(global.window['alt.js.org'][0].alt === alt)
+    },
+
+    afterEach() {
+      delete global.window
+    }
+  },
+
+  'isomorphic debug mode': {
+    'enable debug mode does not make things explode'() {
+      const alt = new Alt()
+      Alt.debug(alt)
+    },
+  }
+}


### PR DESCRIPTION
Adding the chrome debugging to alt core. I'd like to probably add this in as a patch and then remove the chromeDebug util for 0.17.0

This would support multiple alt instances