### PR TITLE
Update Bower package to 0.16.6

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "alt",
-  "version": "0.13.6",
+  "version": "0.16.6",
   "homepage": "https://github.com/goatslacker/alt",
   "authors": [
     "Josh Perez <josh@goatslacker.com>"


### PR DESCRIPTION
Changes:
- Bower will now serve 0.16.6 as the `bower install` default