### PR TITLE
Include a reference to the Getting Started guide in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ There are also many [utils](/src/utils) available which interface well with alt:
 
 ## Topical Guide
 
-Check out the [API Reference](http://alt.js.org/docs/) for full in-depth docs.
+Check out the [API Reference](http://alt.js.org/docs/) for full in-depth docs.  For a high-level walk-through, take a look at the [Getting Started](http://alt.js.org/guide/) guide.
 
 First we install alt through npm. Although alt is also available through bower.
 


### PR DESCRIPTION
For those of us who dwell more on the READMEs than the actual project site, a mention to the existence of the getting started guide can be quite helpful.