### PR TITLE
Add FP goodies baked into alt

### DIFF
--- a/src/alt/store/index.js
+++ b/src/alt/store/index.js
@@ -37,7 +37,10 @@ function createPrototype(proto, alt, key, extras) {
   return fn.assign(proto, StoreMixin, {
     _storeName: key,
     alt: alt,
-    dispatcher: alt.dispatcher
+    dispatcher: alt.dispatcher,
+    preventDefault() {
+      this.getInstance().preventDefault = true
+    }
   }, extras)
 }
 
@@ -72,6 +75,13 @@ export function createStoreFromObject(alt, StoreModel, key) {
     StoreMixin.bindListeners.call(
       StoreProto,
       StoreProto.bindListeners
+    )
+  }
+  /* istanbul ignore else */
+  if (StoreProto.observe) {
+    StoreMixin.bindListeners.call(
+      StoreProto,
+      StoreProto.observe(alt)
     )
   }
 
@@ -117,13 +127,8 @@ export function createStoreFromClass(alt, StoreModel, key, ...argsForClass) {
 
   const store = new Store(...argsForClass)
 
-  if (config.bindListeners) {
-    store.bindListeners(config.bindListeners)
-  }
-
-  if (config.datasource) {
-    store.exportAsync(config.datasource)
-  }
+  if (config.bindListeners) store.bindListeners(config.bindListeners)
+  if (config.datasource) store.registerAsync(config.datasource)
 
   storeInstance = fn.assign(
     new AltStore(

--- a/test/async-test.js
+++ b/test/async-test.js
@@ -74,7 +74,6 @@ const StargazerSource = {
 }
 
 @createStore(alt)
-@datasource(StargazerSource)
 class StargazerStore {
   static config = {
     stateKey: 'state'
@@ -88,6 +87,8 @@ class StargazerStore {
       errorMessage: null,
       isLoading: false
     }
+
+    this.registerAsync(StargazerSource)
 
     this.bindListeners({
       loading: StargazerActions.fetchingUsers,
@@ -240,9 +241,12 @@ export default {
     'as a function'() {
       const FauxSource = sinon.stub().returns({})
 
-      @datasource(FauxSource)
       class FauxStore {
         static displayName = 'FauxStore'
+
+        constructor() {
+          this.exportAsync(FauxSource)
+        }
       }
 
       const store = alt.createStore(FauxStore)
@@ -261,12 +265,11 @@ export default {
         }
       }
 
-      @datasource(PojoSource)
       class MyStore {
         static displayName = 'MyStore'
       }
 
-      const store = alt.createStore(MyStore)
+      const store = alt.createStore(datasource(PojoSource)(MyStore))
 
       assert.isFunction(store.justTesting)
       assert.isFunction(store.isLoading)

--- a/test/es3-module-pattern.js
+++ b/test/es3-module-pattern.js
@@ -45,7 +45,7 @@ export default {
 
     'store method exists'() {
       const storePrototype = Object.getPrototypeOf(myStore)
-      const assertMethods = ['constructor', 'getEventEmitter', 'emitChange', 'listen', 'unlisten', 'getState']
+      const assertMethods = ['constructor', 'getEventEmitter', 'listen', 'unlisten', 'getState']
       assert.deepEqual(Object.getOwnPropertyNames(storePrototype), assertMethods, 'methods exist for store')
       assert.isUndefined(myStore.addListener, 'event emitter methods not present')
       assert.isUndefined(myStore.removeListener, 'event emitter methods not present')

--- a/test/functional-test.js
+++ b/test/functional-test.js
@@ -1,0 +1,147 @@
+import { assert } from 'chai'
+import Alt from '../dist/alt-with-runtime'
+import sinon from 'sinon'
+
+export default {
+  'functional goodies for alt': {
+    'observing for changes in a POJO so we get context passed in'() {
+      const alt = new Alt()
+
+      const observe = sinon.stub().returns({})
+      const displayName = 'store'
+
+      alt.createStore({ displayName, observe })
+
+      assert.ok(observe.calledOnce)
+      assert(observe.args[0][0] === alt, 'first arg is alt')
+    },
+
+    'when observing changes, they are observed'() {
+      const alt = new Alt()
+      const actions = alt.generateActions('fire')
+
+      const displayName = 'store'
+
+      const store = alt.createStore({
+        displayName,
+        observe() {
+          return { fire: actions.fire }
+        },
+        fire() { }
+      })
+
+      assert(store.boundListeners.length === 1, 'there is 1 action bound')
+    },
+
+    'otherwise works like a haskell guard'() {
+      const alt = new Alt()
+      const actions = alt.generateActions('fire', 'test')
+
+      const spy = sinon.spy()
+
+      const store = alt.createStore({
+        displayName: 'store',
+        state: { x: 0 },
+        bindListeners: {
+          fire: actions.fire
+        },
+
+        fire() {
+          this.setState({ x: 1 })
+        },
+
+        otherwise() {
+          this.setState({ x: 2 })
+        }
+      })
+
+      const kill = store.listen(spy)
+
+      actions.test()
+      assert(store.getState().x === 2, 'the otherwise clause was ran')
+
+      actions.fire()
+      assert(store.getState().x === 1, 'just fire was ran')
+
+      assert.ok(spy.calledTwice)
+
+      kill()
+    },
+
+    'preventDefault prevents a change event to be emitted'() {
+      const alt = new Alt()
+      const actions = alt.generateActions('fire')
+
+      const spy = sinon.spy()
+
+      const store = alt.createStore({
+        displayName: 'store',
+        state: { x: 0 },
+        bindListeners: {
+          fire: actions.fire
+        },
+
+        fire() {
+          this.setState({ x: 1 })
+          this.preventDefault()
+        }
+      })
+
+      const kill = store.listen(spy)
+
+      actions.fire()
+      assert(store.getState().x === 1, 'just fire was ran')
+
+      assert(spy.callCount === 0, 'store listener was never called')
+
+      kill()
+    },
+
+    'reduce fires on every dispatch if defined'() {
+      const alt = new Alt()
+      const actions = alt.generateActions('fire')
+
+      const store = alt.createStore({
+        displayName: 'store',
+
+        state: { x: 0 },
+
+        reduce(alt, state) {
+          return { x: state.x + 1 }
+        }
+      })
+
+      actions.fire()
+      actions.fire()
+      actions.fire()
+
+      assert(store.getState().x === 3, 'counter was incremented')
+    },
+
+    'reduce doesnt emit if preventDefault'() {
+      const alt = new Alt()
+      const actions = alt.generateActions('fire')
+
+      const store = alt.createStore({
+        displayName: 'store',
+
+        state: { x: 0 },
+
+        reduce(alt, state) {
+          this.preventDefault()
+          return {}
+        }
+      })
+
+      const spy = sinon.spy()
+
+      const unsub = store.listen(spy)
+
+      actions.fire()
+
+      assert(spy.callCount === 0)
+
+      unsub()
+    },
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -389,7 +389,7 @@ const tests = {
 
   'store methods'() {
     const storePrototype = Object.getPrototypeOf(myStore)
-    const assertMethods = ['constructor', 'getEventEmitter', 'emitChange', 'listen', 'unlisten', 'getState']
+    const assertMethods = ['constructor', 'getEventEmitter', 'listen', 'unlisten', 'getState']
     assert.deepEqual(Object.getOwnPropertyNames(storePrototype), assertMethods, 'methods exist for store')
     assert.isUndefined(myStore.addListener, 'event emitter methods not present')
     assert.isUndefined(myStore.removeListener, 'event emitter methods not present')


### PR DESCRIPTION
Brings in a lot of the ideas of [microflux](https://github.com/goatslacker/microflux) into Alt.

This PR is full of new features:

* preventDefault() is this new method available on the store that will prevent a change event from being emitted. This is a better alternative than returning false from each action handler as this is more explicit. This will also be needed for other methods below.

* observe() is a new method that you define in your store. It was made mostly for when creating stores with POJOs and using alt instances. This method gets `alt` as its first and only parameter and you return an Object from it. The Object contains the same stuff that would go in `bindListeners`. These listeners are then bound.

* otherwise() is a new method you define in your store. This is a concept borrowed from [Haskell's guards](http://learnyouahaskell.com/syntax-in-functions#guards-guards). It is called for every single dispatch that isn't already being handled in your store. So say your store already has handlers for actions A and B and action C fires, this would hit the `otherwise` method. If action A were to be fired then only the handler would react.

* reduce() is a new method you define in your store. This handles *all* dispatches and it is quite a special method since it doesn't work like the other ones. In reduce you return an object which then becomes the next state. This works well if you're looking to create simple stores of derived data or as some call them: ["ephemeral stores"](https://github.com/appsforartists/funx). 

* output(), also a method you define in your store, shapes the data as its emitted in a change event. This is a method where you can transform the state (but not save) before it reaches the store listeners.