### PR TITLE
Add some notes in the documentation about how to create public store methods using es5 syntax. 

### DIFF
--- a/guides/es5/index.md
+++ b/guides/es5/index.md
@@ -48,6 +48,12 @@ function FoodStore() {
   this.bindListeners({
     addItem: foodActions.addItem
   });
+  
+  this.exportPublicMethods({
+    hasFood: function() {
+      return !!this.getState().foods.length;
+    }
+  });
 }
 
 FoodStore.prototype.addItem = function (item) {
@@ -71,6 +77,12 @@ var FoodStore = alt.createStore({
 
   state: {
     foods: []
+  },
+  
+  pubilcMethods: {
+    hasFood: function () {
+      return !!this.getState().foods.length;
+    }
   },
 
   addItem: function (item) {
@@ -104,6 +116,11 @@ function FoodStore(initialFood) {
     state: {
       foods: foods
     },
+    pubilcMethods: {
+      hasFood: function () {
+        return foods.length;
+      }
+    },
 
     addItem: function (item) {
       var foods = this.state.foods;
@@ -118,6 +135,13 @@ function FoodStore(initialFood) {
 var foodStore = alt.createStore(
   FoodStore(['banana', 'strawberry', 'mango', 'orange'])
 );
+```
+
+A less explicit way of creating a public method is to statically define it as property of the store constructor function:
+```
+FoodStore.hasFood = function() {
+  return !!this.getState().length;
+}
 ```
 
 ## Instances


### PR DESCRIPTION
I had to dig around to figure out that a "publicMethods" property could be defined when using the object syntax.  I added this to the es5 guide for anyone else looking for this.  While I was at it, I added examples of the other methods as well.