### PR TITLE
Update Bower package to 0.16.9

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "alt",
-  "version": "0.16.6",
+  "version": "0.16.9",
   "homepage": "https://github.com/goatslacker/alt",
   "authors": [
     "Josh Perez <josh@goatslacker.com>"


### PR DESCRIPTION
Stop leaving us lowly Bower users out in the cold after the version bump. ;)

Changes:
- Bower will now serve 0.16.9 as the `bower install` default