### PR TITLE
fix broken reference to /dist/alt-browser.js

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "Josh Perez <josh@goatslacker.com>"
   ],
   "description": "Alt is a flux implementation that is small (~4.3kb & 400 LOC), well tested, terse, insanely flexible, and forward thinking.",
-  "main": "dist/alt-browser.js",
+  "main": "dist/alt.js",
   "devDependencies": {
     "babel": "^4.0.1",
     "coveralls": "^2.11.2",


### PR DESCRIPTION
* Fixes broken reference to /dist/alt-browser.js, replacing it witth /dist/alt.js

close #321