### PR TITLE
Hoist non-react statics when using connectToStores

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "lib",
   "dependencies": {
     "flux": "2.0.3",
+    "hoist-non-react-statics": "^1.0.2",
     "transmitter": "1.0.2"
   },
   "devDependencies": {

--- a/src/utils/connectToStores.js
+++ b/src/utils/connectToStores.js
@@ -45,6 +45,7 @@
 
 import React from 'react'
 import { assign, isFunction } from './functions'
+import hoistNonReactStatics from 'hoist-non-react-statics'
 
 function connectToStores(Spec, Component = Spec) {
   // Check for required static methods.
@@ -85,6 +86,8 @@ function connectToStores(Spec, Component = Spec) {
       )
     }
   })
+
+  hoistNonReactStatics(StoreConnection, Component)
 
   return StoreConnection
 }

--- a/test/connect-to-stores-test.js
+++ b/test/connect-to-stores-test.js
@@ -130,6 +130,27 @@ export default {
       assert.include(output, 'Foo: Bar')
     },
 
+    'createClass() keeps statics'() {
+      const StaticsComponent = React.createClass({
+        statics: {
+          getStores() {
+            return [testStore]
+          },
+          getPropsFromStores(props) {
+            return testStore.getState()
+          },
+          getFoo() {
+            return 'foo'
+          }
+        },
+        render() {
+          return null
+        }
+      })
+      const WrappedComponent = connectToStores(StaticsComponent)
+      assert(WrappedComponent.getFoo() === 'foo')
+    },
+
     'ES6 class component responds to store events'() {
       class ClassComponent extends React.Component {
         render() {


### PR DESCRIPTION
I noticed that alt only has flux and transmitter as its dependencies... So I'm not sure if you'd wanna add `hoist-non-react-statics` just for connectToStores, which admittedly many people probably won't be using. 

This package was made for fluxible's connectToStores, and I think it'd be useful for alt's connectToStores  to share this behavior.

If you'd prefer to avoid adding the dependency I could add the hoist-non-react-statics code to connectToStores, or another alternative is for me to publish the tweaked connectToStores as a separate module. 

It's also worth noting that it only works with `React.createClass`, since `class` statics are not enumerable. It won't break with class syntax, it just won't hoist statics.