### PR TITLE
Pass source args to loading, success, and error actions

### DIFF
--- a/docs/async.md
+++ b/docs/async.md
@@ -89,7 +89,7 @@ This function is called first. If a value is returned then a change event will b
 
 This function is called whenever we need to fetch a value remotely. `remote` is only called if `local` returns null or undefined as its value, or if `shouldFetch` returns true.
 
-Any arguments passed to your public method will be passed through to both local and remote:
+Any arguments passed to your public method will be passed through to both local and remote, as well as to the loading, success, and error actions:
 
 ```js
 remote(state, one, two, three) {
@@ -98,15 +98,19 @@ remote(state, one, two, three) {
 SearchStore.performSearch(1, 2, 3);
 ```
 
-### success
+### success(resolveValue: any, ...args: any)
 ##### Required
 
 Must be an action. Called whenever a value resolves.
 
-### error
+Called with any arguments passed to the public method.
+
+### error(rejectValue: any, ...args: any)
 ##### Required
 
 Must be an action. Called whenever a value rejects.
+
+Called with any arguments passed to the public method.
 
 ### shouldFetch(state: object, ...args: any)
 _Optional_
@@ -124,10 +128,14 @@ interceptResponse(data, action, args) {
 }
 ```
 
-### loading
+### loading(value: any, ...args: any)
 _Optional_
 
 Must be an action. This function will be called immediately prior to the `remote` function. This call is a synchronous  and is not related to the `isLoading()` method of the store.
+
+Value will be null unless changed by interceptResponse.
+
+Called with any arguments passed to the public method.
 
 ## Decorator
 

--- a/src/alt/store/StoreMixin.js
+++ b/src/alt/store/StoreMixin.js
@@ -53,7 +53,7 @@ const StoreMixin = {
           return (x) => {
             const fire = () => {
               loadCounter -= 1
-              action(intercept(x, action, args))
+              action(intercept(x, action, args), ...args)
               if (isError) throw x
             }
             return this.alt.buffer ? (() => fire()) : fire()
@@ -64,7 +64,7 @@ const StoreMixin = {
         if (shouldFetch) {
           loadCounter += 1
           /* istanbul ignore else */
-          if (spec.loading) spec.loading(intercept(null, spec.loading, args))
+          if (spec.loading) spec.loading(intercept(null, spec.loading, args), ...args)
           return spec.remote(state, ...args).then(
             makeActionHandler(spec.success),
             makeActionHandler(spec.error, 1)

--- a/test/async-test.js
+++ b/test/async-test.js
@@ -29,7 +29,21 @@ const local = sinon.stub(api, 'local', (state) => {
   return state.users.length ? state.users : null
 })
 
+const loading = sinon.spy(StargazerActions.fetchingUsers)
+const success = sinon.spy(StargazerActions.usersReceived)
+const error = sinon.spy(StargazerActions.failed)
+
 const StargazerSource = {
+  fetchUsersArgs () {
+    return {
+      remote,
+      local,
+      loading,
+      success,
+      error
+    }
+  },
+
   fetchUsers() {
     return {
       remote,
@@ -137,6 +151,51 @@ export default {
         })
         class Store { }
       }, Error, /handler must be an action function/)
+    },
+
+    'pass args to loading and error actions'() {
+      const spy = sinon.spy()
+      StargazerStore.listen(spy)
+      StargazerStore.listen(source => {
+        if (spy.callCount === 2) {
+          const loadingArgs = loading.firstCall.args
+          const errorArgs = error.firstCall.args
+
+          assert(loadingArgs.length === 3)
+          assert(errorArgs.length === 3)
+
+          assert(loadingArgs[1] === '')
+          assert(errorArgs[1] === '')
+
+          assert(loadingArgs[2] === 'arg2')
+          assert(errorArgs[2] === 'arg2')
+          done()
+        }
+      })
+      StargazerStore.fetchUsersArgs('', 'arg2')
+    },
+
+    'pass args to loading and success actions'() {
+      const spy = sinon.spy()
+      StargazerStore.listen(spy)
+      StargazerStore.listen(source => {
+        if (spy.callCount === 2) {
+          const loadingArgs = loading.firstCall.args
+          const successArgs = success.firstCall.args
+
+          assert(loadingArgs.length === 3)
+          assert(successArgs.length === 3)
+
+          assert(loadingArgs[1] === 'alts')
+          assert(successArgs[1] === 'alts')
+
+          assert(loadingArgs[2] === 'arg2')
+          assert(successArgs[2] === 'arg2')
+
+          done()
+        }
+      })
+      StargazerStore.fetchUsersArgs('alts', 'arg2')
     },
 
     'loading state'(done) {


### PR DESCRIPTION
This PR makes it so that source args are passed to loading, success, and error actions. 

* Not sure if it should spread or pass it as a single argument
* Open to suggestions for how to make the tests better