### PR TITLE
A sweet spankin' new Render

### DIFF
--- a/src/utils/AltIso.js
+++ b/src/utils/AltIso.js
@@ -13,13 +13,18 @@ export default {
             fulfilled: obj.fulfilled
           })
         }
-      }).catch((err) => {
-        // return the empty markup in html when there's an error
-        return {
-          err,
-          html: Iso.render()
+      }).catch(
+        /* istanbul ignore next */
+        (err) => {
+          // this is a fail-safe case you should never hit. In case there's an
+          // error flushing alt or something blows up then we should render
+          // empty markup so that we can bootstrap anyway and render client side.
+          return {
+            err,
+            html: Iso.render()
+          }
         }
-      })
+      )
     } else {
       Iso.bootstrap((state, meta, node) => {
         alt.bootstrap(state)

--- a/src/utils/AltIso.js
+++ b/src/utils/AltIso.js
@@ -1,14 +1,17 @@
 import Iso from 'iso'
-import * as Render from './Render'
+import Render from './Render'
 
 export default {
-  define: Render.withData,
+  define: Render.resolve,
+  resolve: Render.resolve,
 
   render(alt, Component, props) {
     if (typeof window === 'undefined') {
-      return Render.toString(alt, Component, props).then((obj) => {
+      return new Render(alt).toString(Component, props).then((obj) => {
         return {
-          html: Iso.render(obj.html, obj.state, { iso: 1 })
+          html: Iso.render(obj.html, obj.state, {
+            fulfilled: obj.fulfilled
+          })
         }
       }).catch((err) => {
         // return the empty markup in html when there's an error
@@ -20,7 +23,7 @@ export default {
     } else {
       Iso.bootstrap((state, meta, node) => {
         alt.bootstrap(state)
-        Render.toDOM(Component, props, node, meta.iso)
+        new Render(alt).toDOM(Component, props, node, meta)
       })
       return Promise.resolve()
     }

--- a/src/utils/Render.js
+++ b/src/utils/Render.js
@@ -4,27 +4,36 @@ export function withData(fetch, MaybeComponent) {
   function bind(Component) {
     return React.createClass({
       contextTypes: {
+        universalId: React.PropTypes.string.isRequired,
         buffer: React.PropTypes.object.isRequired
       },
 
       childContextTypes: {
+        universalId: React.PropTypes.string.isRequired,
         buffer: React.PropTypes.object.isRequired
       },
 
       getChildContext() {
-        return { buffer: this.context.buffer }
+        const children = this.props.children || []
+        const universalId = `${this.context.universalId}.${children.length}`
+        return {
+          universalId,
+          buffer: this.context.buffer
+        }
       },
 
       componentWillMount() {
-        if (!this.context.buffer.locked) {
+        if (this.context.buffer.shouldFetch(this.context.universalId)) {
           this.context.buffer.push(
+            this.context.universalId,
             fetch(this.props)
           )
         }
       },
 
       render() {
-        return this.context.buffer.locked
+        // XXX I need to make sure I can render since this promise has fulfilled successfully!
+        return this.context.buffer.shouldRender(this.context.universalId)
           ? React.createElement(Component, this.props)
           : null
       }
@@ -42,11 +51,15 @@ function call(f) {
 function usingDispatchBuffer(buffer, Component) {
   return React.createClass({
     childContextTypes: {
+      universalId: React.PropTypes.string.isRequired,
       buffer: React.PropTypes.object.isRequired
     },
 
     getChildContext() {
-      return { buffer }
+      return {
+        universalId: 'root',
+        buffer
+      }
     },
 
     render() {
@@ -58,46 +71,82 @@ function usingDispatchBuffer(buffer, Component) {
 class DispatchBuffer {
   constructor(renderStrategy) {
     this.promisesBuffer = []
+    this.fetched = {}
+    this.fulfilled = {}
+    this.dispatches = []
     this.locked = false
     this.renderStrategy = renderStrategy
   }
 
-  push(v) {
-    this.promisesBuffer.push(v)
+  push(id, promise) {
+    this.promisesBuffer.push(promise)
+    promise.then(() => this.fulfilled[id] = true)
+    this.fetched[id] = true
   }
 
-  fill(Element) {
-    return this.renderStrategy(Element)
+  shouldFetch(id) {
+    return !this.fetched[id]
+//    return !this.locked && !this.fetched[this.promisesBuffer.length]
+  }
+
+  shouldRender(id) {
+    return this.fulfilled[id]
   }
 
   clear() {
     this.promisesBuffer = []
   }
 
-  flush(alt, Element) {
-    return Promise.all(this.promisesBuffer).then((data) => {
-      // fire off all the actions synchronously
-      data.forEach((f) => {
-        if (Array.isArray(f)) {
-          f.forEach(call)
-        } else {
-          call(f)
+  // XXX need to add a timeout/iteration limit
+  // XXX study a fail case, make sure when it does fail it sends down partial markup of what was already resolved. we can client render the rest
+  render(alt, Element, i = 0) {
+    alt.recycle()
+
+    // fire off all the actions synchronously
+    this.dispatches.forEach((f) => {
+      if (Array.isArray(f)) {
+        f.forEach(call)
+      } else {
+        call(f)
+      }
+    })
+
+    // render the html
+    const html = this.renderStrategy(Element)
+
+    // do we have new async queries we need to take care of?
+    if (this.promisesBuffer.length) {
+      // resolve them
+      return Promise.all(this.promisesBuffer).then((data) => {
+        // add the dispatches to our queue
+        this.dispatches = this.dispatches.concat(data)
+
+        // clear the buffer and call render again
+        this.promisesBuffer = []
+
+        return this.render(alt, Element, i + 1)
+      }).catch((e) => {
+
+        // XXX need a better story here
+//        console.error(e)
+        return 'derp'
+      })
+    } else {
+      return Promise.resolve({
+        html,
+        state: alt.flush(),
+        element: Element,
+        diagnostics: {
+          iterations: i,
+          dispatches: this.dispatches.length
         }
       })
-      this.locked = true
+    }
 
-      return {
-        html: this.renderStrategy(Element),
-        state: alt.flush(),
-        element: Element
-      }
-    }).catch((err) => {
-      return Promise.reject({
-        err,
-        state: alt.flush(),
-        element: Element
-      })
-    })
+    // so bookeeping: we need to keep track of all the dispatches that have happened, queue them up and replay them when all is said and done.
+    // we need to clear the promise buffer on render and then re-render, but only lock certain calls from happening (the ones that have happened/returned)
+    // XXX enhancement: we also should probably cache same calls with same args and just return the promise in that instance.
+    // XXX i need to create deterministic id's for all this shit.
   }
 }
 
@@ -115,12 +164,22 @@ function renderWithStrategy(strategy) {
     // cache the element
     const Element = React.createElement(Container, props)
 
-    // render so we kick things off and get the props
-    buffer.fill(Element)
+    const start = Date.now()
 
-    // flush out the results in the buffer synchronously setting the store
-    // state and returning the markup
-    return buffer.flush(alt, Element)
+    return buffer.render(alt, Element).then((obj) => {
+      const time = Date.now() - start
+
+      return {
+        html: obj.html,
+        state: obj.state,
+        element: obj.element,
+        diagnostics: {
+          iterations: obj.diagnostics.iterations,
+          dispatches: obj.diagnostics.dispatches,
+          time
+        }
+      }
+    })
   }
 }
 

--- a/src/utils/Render.js
+++ b/src/utils/Render.js
@@ -1,9 +1,5 @@
 import React from 'react'
 
-function call(f) {
-  if (typeof f === 'function') f()
-}
-
 function usingDispatchBuffer(buffer, Component) {
   return React.createClass({
     childContextTypes: {
@@ -74,9 +70,9 @@ class DispatchBuffer {
     // fire off all the actions synchronously
     this.dispatches.forEach((f) => {
       if (Array.isArray(f)) {
-        f.forEach(call)
+        f.forEach(x => x())
       } else {
-        call(f)
+        f()
       }
     })
 

--- a/src/utils/Render.js
+++ b/src/utils/Render.js
@@ -83,8 +83,6 @@ class DispatchBuffer {
     // render the html
     const html = this.renderStrategy(Element)
 
-    console.log('@', info)
-
     if (i >= info.maxIterations) {
       return this.resolve(
         new Error('Max number of iterations reached'),

--- a/test/alt-iso-browser-test.js
+++ b/test/alt-iso-browser-test.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react'
 import Alt from '../'
 import AltContainer from '../AltContainer'
 import AltIso from '../utils/AltIso'
-import * as Render from '../utils/Render'
+import Render from '../utils/Render'
 import connectToStores from '../utils/connectToStores'
 import { assert } from 'chai'
 
@@ -178,7 +178,7 @@ export default {
         this.bindAction(actions.fail, err => console.log('STORE FETCH ERROR HANDLER', err))
       }, 'Store')
 
-      const App = Render.withData((props) => {
+      const App = Render.resolve((props) => {
         return Store.bananas()
       }, connectToStores(class extends Component {
         static getStores() {
@@ -194,7 +194,7 @@ export default {
         }
       }))
 
-      Render.toString(alt, App)
+      new Render(alt).toString(App)
         .then((obj) => {
           assert.isString(obj.html)
           assert.match(obj.html, /2222222/)


### PR DESCRIPTION
* Changes Render API to be more sensible?
* Performs a few iterations when rendering so we can render child components that need data resolved.
* Partial rendering, if one component errors it doesn't taken down the entire render tree. We'll render what we've got and then client side render the rest.
* No need to perform if-checks in your React render methods, all components are only rendered if their props are resolved. We keep track of what's been resolved and don't re-fetch client side.
* You can still keep your singletons and have concurrent server requests.
* Now you get a spiffy error object telling you what went wrong. No more need to .then().catch() it, everything is just returned in .then()
* You also get a nice diagnostics object telling you how many iterations it took, and how long it took (in ms) to resolve + render.

@taion @jfsiii @jdlehman 