### PR TITLE
Add async functions to AltTestingUtils

### DIFF
--- a/src/utils/AltTestingUtils.js
+++ b/src/utils/AltTestingUtils.js
@@ -12,9 +12,11 @@ const AltTestingUtils = {
       bindListeners: noop,
       dispatcher: alt.dispatcher,
       emitChange: noop,
+      exportAsync: noop,
       exportPublicMethods: noop,
       getInstance: noop,
       on: noop,
+      registerAsync: noop,
       setState: noop,
       waitFor: noop
     }


### PR DESCRIPTION
Add exportAsync and registerAsync noop functions, missing from AltTestingUtils.

Closes #397 