### PR TITLE
Context free render

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,7 @@
     "modules": true,
     "jsx": true
   },
+  "parser": "babel-eslint",
   "plugins": [
     "react"
   ],

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "alt-search-docs": "1.0.6",
     "babel": "^5.3.1",
     "babel-core": "^5.3.1",
+    "babel-eslint": "^3.1.23",
     "babelify": "^6.1.0",
     "browserify": "^10.1.3",
     "browserify-shim": "^3.8.6",

--- a/src/alt/index.js
+++ b/src/alt/index.js
@@ -204,6 +204,15 @@ class Alt {
     return this.stores[name]
   }
 
+  fetch(future, onSuccess, onFailure) {
+    if (!this.buffer) {
+      future.then(onSuccess, onFailure)
+    } else {
+      this.buffer.futures.push(future.then(x => [true, x], e => [false, e]))
+      this.buffer.continuations.push({onSuccess, onFailure})
+    }
+  }
+
   static debug(name, alt) {
     const key = 'alt.js.org'
     if (typeof window !== 'undefined') {

--- a/src/alt/store/index.js
+++ b/src/alt/store/index.js
@@ -32,6 +32,9 @@ function createPrototype(proto, alt, key, extras) {
   proto.publicMethods = {}
   proto.handlesOwnErrors = false
 
+  // This doesn't need to be serialized - the data will be enough
+  proto.pendingFetches = {}
+
   return fn.assign(proto, StoreMixin, {
     displayName: key,
     alt: alt,

--- a/src/utils/Render.js
+++ b/src/utils/Render.js
@@ -121,7 +121,6 @@ class DispatchBuffer {
         // this takes the rendering out of a Promise context
         // TODO test this concurrently
         return this.render(alt, Element, info)
-//        return setTimeout(() => this.render(alt, Element, info))
       }).catch((error) => {
         const errorHtml = this.renderStrategy(Element)
         return this.resolve(error, errorHtml, alt, Element, i)
@@ -286,6 +285,8 @@ export function connect(Spec, MaybeComponent) {
             return Spec.failed
               ? this.renderIfValid(Spec.failed(this.props, this.context))
               : null
+          default:
+            throw new Error('unrecognized status')
         }
       }
     })

--- a/src/utils/Render.js
+++ b/src/utils/Render.js
@@ -1,301 +1,58 @@
 import React from 'react'
 
-const STAT = {
-  READY: 0,
-  DONE: 1,
-  LOADING: 2,
-  FAILED: 3
-}
+function renderWithStrategy(
+  alt,
+  renderFunc,
+  Element,
+  info,
+  start = Date.now(),
+  iterations = 0,
+  lastResults = null
+) {
+  // FIXME: Add error handling here.
 
-function usingDispatchBuffer(buffer, Component) {
-  return React.createClass({
-    childContextTypes: {
-      universalId: React.PropTypes.string.isRequired,
-      buffer: React.PropTypes.object.isRequired
-    },
+  if (lastResults) {
+    alt.bootstrap(lastResults.state)
 
-    getChildContext() {
-      return {
-        universalId: 'root',
-        buffer
-      }
-    },
+    lastResults.futureResults.forEach((futureResult, i) => {
+      const [succeeded, result] = futureResult
+      const continuation = lastResults.continuations[i]
 
-    render() {
-      return React.createElement(Component, this.props)
-    }
-  })
-}
-
-class DispatchBuffer {
-  constructor(renderStrategy) {
-    this.promisesBuffer = []
-    this.status = {}
-    this.dispatches = []
-    this.renderStrategy = renderStrategy
-  }
-
-  push(id, promise) {
-    this.promisesBuffer.push(promise)
-    promise.then(
-      () => this.status[id] = STAT.DONE,
-      () => this.status[id] = STAT.FAILED
-    )
-  }
-
-  getStatus(id) {
-    return this.status[id] || STAT.READY
-  }
-
-  clear() {
-    this.promisesBuffer = []
-  }
-
-  resolve(error, html, alt, Element, i) {
-    return Promise.resolve({
-      error,
-      html,
-      state: alt.flush(),
-      buffer: {
-        status: this.status
-      },
-      element: Element,
-      diagnostics: {
-        iterations: i,
-        dispatches: this.dispatches.length
-      }
-    })
-  }
-
-  render(alt, Element, info) {
-    alt.recycle()
-
-    const startTime = Date.now()
-    const i = info.i || 0
-
-    // fire off all the actions synchronously
-    this.dispatches.forEach((f) => {
-      if (Array.isArray(f)) {
-        f.forEach(x => x())
+      if (succeeded) {
+        continuation.onSuccess(result)
       } else {
-        f()
-      }
-    })
-
-    // render the html
-    const html = this.renderStrategy(Element)
-
-    if (i >= info.maxIterations) {
-      return this.resolve(
-        new Error('Max number of iterations reached'),
-        html,
-        alt,
-        Element,
-        i
-      )
-    }
-
-    if (info.time > info.timeout) {
-      return this.resolve(
-        new Error('Render timed out'),
-        html,
-        alt,
-        Element,
-        i
-      )
-    }
-
-    // do we have new async queries we need to take care of?
-    if (this.promisesBuffer.length) {
-      // resolve them
-      return Promise.all(this.promisesBuffer).then((data) => {
-        // add the dispatches to our queue
-        this.dispatches = this.dispatches.concat(data)
-
-        // clear the buffer and call render again
-        this.promisesBuffer = []
-
-        info.i = i + 1
-        info.time = info.time + (Date.now() - startTime)
-
-        // this takes the rendering out of a Promise context
-        // TODO test this concurrently
-        return this.render(alt, Element, info)
-      }).catch((error) => {
-        const errorHtml = this.renderStrategy(Element)
-        return this.resolve(error, errorHtml, alt, Element, i)
-      })
-    } else {
-      return this.resolve(null, html, alt, Element, i)
-    }
-  }
-}
-
-function renderWithStrategy(strategy) {
-  return (alt, Component, props, info) => {
-    alt.buffer = true
-
-    // create a buffer and use context to pass it through to the components
-    const buffer = new DispatchBuffer((Node) => {
-      return React[strategy](Node)
-    })
-    const Container = usingDispatchBuffer(buffer, Component)
-
-    // cache the element
-    const Element = React.createElement(Container, props)
-
-    const start = Date.now()
-
-    return buffer.render(alt, Element, info).then((obj) => {
-      const time = Date.now() - start
-
-      return {
-        error: obj.error,
-        html: obj.html,
-        state: obj.state,
-        buffer: obj.buffer,
-        element: obj.element,
-        diagnostics: {
-          iterations: obj.diagnostics.iterations,
-          dispatches: obj.diagnostics.dispatches,
-          time
-        }
-      }
-    })
-  }
-}
-
-export function connect(Spec, MaybeComponent) {
-  function bind(Component) {
-    return React.createClass({
-      contextTypes: {
-        universalId: React.PropTypes.string.isRequired,
-        buffer: React.PropTypes.object.isRequired
-      },
-
-      childContextTypes: {
-        universalId: React.PropTypes.string.isRequired,
-        buffer: React.PropTypes.object.isRequired
-      },
-
-      getChildContext() {
-        const children = this.props.children || []
-        const universalId = `${this.context.universalId}.${children.length}`
-        return {
-          universalId,
-          buffer: this.context.buffer
-        }
-      },
-
-      getInitialState() {
-        return {
-          status: this.context.buffer.getStatus(this.context.universalId),
-          props: Spec.reduceProps(this.props, this.context) || {}
-        }
-      },
-
-      componentWillReceiveProps(nextProps) {
-        // resolve whenever props change
-        if (Spec.resolveAsync) this.resolveAsyncClient(nextProps)
-
-        if (Spec.willReceiveProps) {
-          Spec.willReceiveProps(nextProps, this.props, this.context)
-        }
-      },
-
-      componentWillMount() {
-        // resolve when ready on server
-        if (
-          Spec.resolveAsync &&
-          typeof window === 'undefined' &&
-          this.state.status === STAT.READY
-        ) {
-          this.resolveAsyncServer()
-        }
-
-        if (Spec.willMount) Spec.willMount(this.props, this.context)
-      },
-
-      componentDidMount() {
-        if (Spec.listenTo) {
-          const stores = Spec.listenTo(this.props, this.context)
-          this.storeListeners = stores.map((store) => {
-            return store.listen(this.onChange)
-          })
-        }
-
-        // resolve on client if failed from server
-        if (Spec.resolveAsync && this.state.status === STAT.FAILED) {
-          this.resolveAsyncClient(this.props)
-        }
-
-        if (Spec.didMount) Spec.didMount(this.props, this.context)
-      },
-
-      componentWillUnmount() {
-        this.storeListeners.forEach(unlisten => unlisten())
-      },
-
-      onChange() {
-        this.setState({
-          props: Spec.reduceProps(this.props, this.context) || {}
-        })
-      },
-
-      resolveAsyncClient(props) {
-        // client side we setup a listener for loading and done
-        const promise = Spec.resolveAsync(props, this.context)
-
-        if (promise) {
-          this.setState({ status: STAT.LOADING })
-          promise.then(
-            () => this.setState({ status: STAT.DONE }),
-            () => this.setState({ status: STAT.FAILED })
-          )
-        }
-      },
-
-      resolveAsyncServer() {
-        // server side we push it into our buffer
-        const promise = Spec.resolveAsync(this.props, this.context)
-        if (promise) {
-          this.context.buffer.push(this.context.universalId, promise)
-        }
-      },
-
-      renderIfValid(val) {
-        return React.isValidElement(val)
-          ? val
-          : <Component {...val} />
-      },
-
-      render() {
-        const { status } = this.state
-
-        switch (status) {
-          case STAT.READY:
-            return null
-          case STAT.DONE:
-            return <Component {...this.state.props} />
-          case STAT.LOADING:
-            return Spec.loading
-              ? this.renderIfValid(Spec.loading(this.props, this.context))
-              : null
-          case STAT.FAILED:
-            return Spec.failed
-              ? this.renderIfValid(Spec.failed(this.props, this.context))
-              : null
-          default:
-            throw new Error('unrecognized status')
-        }
+        continuation.onError(result)
       }
     })
   }
 
-  // works as a decorator or as a function
-  return MaybeComponent
-    ? bind(MaybeComponent)
-    : Component => bind(Component)
+  const futures = []
+  const continuations = []
+  alt.buffer = {futures, continuations}
+
+  const html = renderFunc(Element)
+
+  alt.buffer = null
+  const state = alt.flush()
+
+  if (futures.length) {
+    return Promise.all(futures).then(futureResults => renderWithStrategy(
+      alt,
+      renderFunc,
+      Element,
+      info,
+      start,
+      iterations + 1,
+      {state, futureResults, continuations}
+    ))
+  } else {
+    const time = Date.now() - start
+
+    return Promise.resolve({
+      html, state,
+      diagnostics: {iterations, time}
+    })
+  }
 }
 
 export default class Render {
@@ -309,43 +66,21 @@ export default class Render {
     this.options.maxIterations = options.maxIterations || 5
   }
 
-  toString(Component, props) {
-    this.options.i = 0
-    this.options.time = 0
-    return renderWithStrategy('renderToString')(
+  toString(Element) {
+    return renderWithStrategy(
       this.alt,
-      Component,
-      props,
+      React.renderToString,
+      Element,
       this.options
     )
   }
 
-  toStaticMarkup(Component, props) {
-    this.options.i = 0
-    this.options.time = 0
-    return renderWithStrategy('renderToStaticMarkup')(
+  toStaticMarkup(Element) {
+    return renderWithStrategy(
       this.alt,
-      Component,
-      props,
+      React.renderToStaticMarkup,
+      Element,
       this.options
     )
   }
-
-  getReady(Component, props, opts = {}) {
-    const buffer = new DispatchBuffer()
-
-    if (opts.status) buffer.status = opts.status
-    const Node = usingDispatchBuffer(buffer, Component)
-    const Element = React.createElement(Node, props)
-    buffer.clear()
-    return Promise.resolve(Element)
-  }
-
-  toDOM(Component, props, documentNode, opts = {}) {
-    return this.getReady(Component, props, opts).then((Element) => {
-      return React.render(Element, documentNode)
-    })
-  }
-
-  static connect = connect
 }

--- a/src/utils/createContainer.js
+++ b/src/utils/createContainer.js
@@ -1,0 +1,71 @@
+import React from 'react'
+
+import {PENDING} from './sentinels'
+
+function defaultPending() {
+  return (<div />)
+}
+
+export default function createContainer(
+  Component,
+  {
+    listenTo,
+    props = {},
+    pending = defaultPending
+  }
+) {
+  const listenToArr = listenTo instanceof Array ? listenTo : [listenTo]
+
+  return React.createClass({
+    componentDidMount() {
+      this.storeListeners = listenToArr.map(
+        store => store.listen(this.onChange)
+      )
+    },
+
+    componentWillUnmount() {
+      this.storeListeners.forEach(unlisten => unlisten())
+    },
+
+    getInitialState() {
+      return this.getState()
+    },
+
+    componentWillReceiveProps(nextProps) {
+      // So getState will see new props.
+      this.props = nextProps
+
+      this.onChange()
+    },
+
+    onChange() {
+      this.setState(this.getState())
+    },
+
+    getState() {
+      const storeProps = {}
+      let isPending = false
+
+      Object.keys(props).forEach(propName => {
+        const propValue = props[propName].call(this)
+
+        storeProps[propName] = propValue
+        if (propValue === PENDING) {
+          isPending = true
+        }
+      })
+
+      return {storeProps, isPending}
+    },
+
+    render() {
+      if (this.state.isPending) {
+        return pending.call(this)
+      }
+
+      return (
+        <Component {...this.props} {...this.state.storeProps} />
+      )
+    }
+  })
+}

--- a/src/utils/sentinels.js
+++ b/src/utils/sentinels.js
@@ -1,0 +1,1 @@
+export const PENDING = {}


### PR DESCRIPTION
Obviously not merge-able, but just a trivial PoC, with

1. Marty-style `createContainer` that handles everything
2. App-level interception of fetches to combine fetch resolution and prop reduction
3. Extremely hackish pending fetch tracking (by ID) on the stores
4. Simpler render loop that just does bootstrap -> dispatch -> flush
5. No use of React context anywhere