### PR TITLE
Enable hot loading for stores if not in production

### DIFF
--- a/src/alt/index.js
+++ b/src/alt/index.js
@@ -46,6 +46,15 @@ class Alt {
   }
 
   createStore(StoreModel, iden, ...args) {
+    // allow hot loading for development usage
+    if (process.env.NODE_ENV !== 'production') {
+      if (module.hot) {
+        module.hot.dispose(() => {
+          delete this.stores[name]
+        })
+      }
+    }
+
     let key = iden || StoreModel.displayName || StoreModel.name || ''
     store.createStoreConfig(this.config, StoreModel)
     const Store = store.transformStore(this.storeTransforms, StoreModel)


### PR DESCRIPTION
I tested this against an app of mine and it worked like a charm. Of course you may want to try it too before merging.

You might want to deprecate `makeHot` at some point as this little change makes it redundant.

Closes #408.