### PR TITLE
Use custom onSerialize method if present when saving initial snapshot

### DIFF
--- a/src/alt/utils/StateFunctions.js
+++ b/src/alt/utils/StateFunctions.js
@@ -30,8 +30,12 @@ export function snapshot(instance, storeNames = []) {
 }
 
 export function saveInitialSnapshot(instance, key) {
+  const store = instance.stores[key]
+  const { config } = store.StoreModel
+  const customState = config.onSerialize &&
+    config.onSerialize(store.state)
   const state = instance.deserialize(
-    instance.serialize(instance.stores[key].state)
+    instance.serialize(customState ? customState : store.state)
   )
   instance._initSnapshot[key] = state
   instance._lastSnapshot[key] = state

--- a/test/index.js
+++ b/test/index.js
@@ -414,7 +414,6 @@ const tests = {
 
     assert(lifecycleStore.getState().bootstrapped === false, 'bootstrap has not been called yet')
     assert(lifecycleStore.getState().snapshotted === false, 'takeSnapshot has not been called yet')
-    assert(lifecycleStore.getState().serialized === false, 'takeSnapshot has not been called yet')
     assert(lifecycleStore.getState().rollback === false, 'rollback has not been called')
     assert(lifecycleStore.getState().init === true, 'init gets called when store initializes')
     assert(lifecycleStore.getState().deserialized === true, 'deserialize has not been called yet')


### PR DESCRIPTION
I was having trouble trying to create a store that has a reference to Firebase. I can do it with `createUnsavedStore()`, but I'm trying to use `altmanager`, and that dosen't work with unsaved stores.

The error when calling `createStore()` was `Uncaught TypeError: Converting circular structure to JSON`.

I created a custom serializer but it seems that the initial snapshot when `createStore()` is called does not use the custom serializer if present. This fixes that. 

The fix caused one test to fail, because the assumption was that a newly created store has never been serialized. This was actually incorrect, because it's always serialized at creation, it just wasn't detectable before. So I just removed the test. 