### PR TITLE
Set state in mixinContainer after mounting

### DIFF
--- a/components/mixinContainer.js
+++ b/components/mixinContainer.js
@@ -46,6 +46,7 @@ function mixinContainer(React) {
 
     componentDidMount: function () {
       this.registerStores(this.props)
+      this.altSetState(this.props)
     },
 
     componentWillUnmount: function () {

--- a/test/store-listener-component-test.js
+++ b/test/store-listener-component-test.js
@@ -327,7 +327,7 @@ export default {
         </AltContainer>
       )
 
-      assert.ok(storeFunction.calledTwice, 'called twice, once for store listening and another for props')
+      assert.ok(storeFunction.calledThrice, 'called thrice, once for store listening, once for initial props, and another for props after mounting')
       assert(storeFunction.args[0].length === 1, 'called with one parameter')
       assert(storeFunction.args[1].length === 1, 'called with one parameter')
       assert.isObject(storeFunction.args[0][0], 'called with the props')
@@ -379,12 +379,12 @@ export default {
 
     'custom rendering'() {
       const render = sinon.stub()
-      render.onCall(0).returns(null)
+      render.returns(<span />)
       TestUtils.renderIntoDocument(
         <AltContainer render={render} />
       )
 
-      assert.ok(render.calledOnce, 'render was called')
+      assert.ok(render.calledTwice, 'render was called twice, initially and after post-mount setState')
 
       const node = TestUtils.renderIntoDocument(
         <AltContainer
@@ -493,7 +493,7 @@ export default {
       )
 
       action.sup()
-      assert.ok(scu.calledOnce, 'custom shouldComponentUpdate was called')
+      assert.ok(scu.calledTwice, 'custom shouldComponentUpdate was called twice, once on initial render, and another after post-mount setState')
       assert(scu.args[0].length === 1, 'only one arg is passed, the props')
       assert.isDefined(scu.args[0][0].x, 'x prop exists')
     },


### PR DESCRIPTION
Hey! Thanks for Alt, it's rad. This feels sort of dumb but wanted to run it by you. 

I hit this edge case today-- I have a component that renders a Google map. After mounting it persists a reference to the map instance in a store. My components are inside an `AltContainer`, with a structure like this:

```
Page
  > AltContainer
    > Map
    > OtherStuff
```

The AltContainer mounts after the Map does, which means that in between the container's `getInitialState` and subscribing to my store, the store's state changes, and the container isn't aware of it.

This PR adds an `altSetState` call after the container mounts, which solves this problem by causing an additional render, which is a bummer.

My current workaround in my app is to defer the action that the map fires, which makes me feel bad about myself but works.