### PR TITLE
ImmutableUtil Store's setState should merge state

### DIFF
--- a/docs/utils/immutable.md
+++ b/docs/utils/immutable.md
@@ -57,8 +57,9 @@ alt.createStore(immutable(TodoStore));
 A few things to note about immutable stores about this approach:
 
 * You use `this.state` to create your state rather than assigning directly to instance properties.
-* You specify your own Immutable data structure you wish to use, as long as it supports `merge`. In this example we're using Map.
-
+* It is highly recommended that you use an `Immutable.Map` as the top level state.
+  * `merge` will be called whenever calling `this.setState`, so other structures can be used as long they support `merge`
+  * WARNING: `Immutable.List` will likely not behave as you expect when calling `setState` in the current version of `Immutable`.  See [this issue](https://github.com/facebook/immutable-js/issues/406) for more information.  Instead it is recommended to nest the `List` in a `Map` as shown above.
 
 Changing the state of your ImmutableStore is a bit different from using a regular store:
 

--- a/docs/utils/immutable.md
+++ b/docs/utils/immutable.md
@@ -30,9 +30,10 @@ class TodoStore {
   static displayName = 'TodoStore'
 
   constructor() {
-    this.state = {
-      todos: Immutable.Map({})
-    };
+    this.state = Immutable.Map({
+      todos: Immutable.List([]),
+      loading: false
+    });
   }
 }
 
@@ -44,7 +45,8 @@ If you don't wish to use ES7 decorators then no problem, they're just sugar for 
 ```js
 function TodoStore() {
   this.state = Immutable.Map({
-    todos: Immutable.Map({})
+    todos: Immutable.List([]),
+    loading: false
   });
 }
 TodoStore.displayName = 'TodoStore';
@@ -55,24 +57,30 @@ alt.createStore(immutable(TodoStore));
 A few things to note about immutable stores about this approach:
 
 * You use `this.state` to create your state rather than assigning directly to instance properties.
-* You specify your own Immutable data structure you wish to use. In this example we're using Map.
+* You specify your own Immutable data structure you wish to use, as long as it supports `merge`. In this example we're using Map.
 
-Using your ImmutableStore is a bit different from using a regular store:
+
+Changing the state of your ImmutableStore is a bit different from using a regular store:
 
 ```js
 function TodoStore() {
   this.state = Immutable.Map({
-    todos: Immutable.Map({})
+    todos: Immutable.List([]),
+    loadingFalse
   });
 
   this.bindListeners({
-    addTodo: TodoActions.addTodo
+    addTodo: TodoActions.ADD_TODO,
+    fetchFromServer, TodoActions.FETCH_FROM_SERVER
   });
 }
 
+TodoStore.prototype.fetchTodos = function() {
+  this.setState({loading: true});
+}
+
 TodoStore.prototype.addTodo = function (todo) {
-  var id = String(Math.random());
-  this.setState(this.state.setIn(['todos', id], todo));
+  this.setState({todos: this.state.get('todos').push(todo)});
 };
 
 TodoStore.displayName = 'TodoStore';
@@ -81,7 +89,8 @@ var todoStore = alt.createStore(immutable(TodoStore));
 ```
 
 * You'll be using `setState` in order to modify state within the store.
-* You can access the immutable object by using the accessor of `this.state`. In this example we're using Map's `set` method to set a new key and value.
+* You can access the immutable object by using the accessor of `this.state`.
+* Anything passed to `setState` will be [merged](https://facebook.github.io/immutable-js/docs/#/Map/merge) with the current state.
 
 ```js
 todoStore.getState() // Immutable.Map

--- a/src/utils/ImmutableUtil.js
+++ b/src/utils/ImmutableUtil.js
@@ -3,7 +3,7 @@ import Immutable from 'immutable'
 function immutable(StoreModel) {
   StoreModel.config = {
     setState(currentState, nextState) {
-      this.state = nextState
+      this.state = currentState.merge(nextState)
       return this.state
     },
 

--- a/test/immutable-stores.js
+++ b/test/immutable-stores.js
@@ -22,19 +22,19 @@ export default {
       const store1 = alt.createStore(immutable({
         displayName: 'ImmutableStore',
         bindListeners: { addY: action.addY, addX: action.addX },
-        state: Immutable.Map({ x: 1 }),
+        state: Immutable.Map({ x: 1, z: 3 }),
         addY() {
-          this.setState(this.state.set('y', 2))
+          this.setState({y: 2})
         },
         addX() {
-          this.setState(this.state.set('x', 5))
+          this.setState({x: 5})
         }
       }))
 
       const store2 = alt.createStore({
         displayName: 'MutableStore',
         bindListeners: { addY: action.addY, addX: action.addX },
-        state: { x: 1 },
+        state: { x: 1, z: 3 },
         addY() {
           this.setState({ y: 2 })
         },
@@ -90,15 +90,15 @@ export default {
         }
 
         handleUpdateBar(x) {
-          this.setState(this.state.set('bar', x))
+          this.setState({bar: x})
         }
 
         handleReplaceMap(x) {
-          this.setState(this.state.set('map', Immutable.fromJS(x).toMap()))
+          this.setState({map: Immutable.fromJS(x).toMap()})
         }
 
         handleReplaceList(x) {
-          this.setState(this.state.set('list', Immutable.fromJS(x).toList()))
+          this.setState({list: Immutable.fromJS(x).toList()})
         }
       }
 
@@ -161,7 +161,7 @@ export default {
         },
 
         handleFoo: function (x) {
-          this.setState(this.state.set('foo', x))
+          this.setState({foo: x})
         }
       }))
 
@@ -203,7 +203,7 @@ export default {
       }
 
       ImmutableStore.prototype.handleFoo = function (x) {
-        this.setState(this.state.set('foo', x))
+        this.setState({foo: x})
       }
 
       ImmutableStore.displayName = 'ImmutableStore'
@@ -247,11 +247,11 @@ export default {
         }
 
         handleFoo(x) {
-          this.setState(this.state.set('foo', x))
+          this.setState({foo: x})
         }
 
         remove() {
-          this.setState(this.state.delete('foo'))
+          this.setState({foo: null})
         }
       }
 
@@ -277,7 +277,7 @@ export default {
 
       actions.rm()
 
-      assert.isUndefined(store.getState().toJS().foo, 'foo has been removed')
+      assert.isNull(store.getState().toJS().foo, 'foo has been set to null')
     },
   }
 }


### PR DESCRIPTION
Currently when using `ImmutableUtil` to use Immutable data in a Store, calling `setState` replaces the current state with the argument passed, which is unexpected as it does not behave like `setState` in React components.

This PR changes `setState` to merge the new provided state with the current state.

There are a few edge cases that become odder with this change, such as removing a key from an `Immutable.Map` (see tests), but overall I think it is a win and much less confusing to users.

Note that this could potentially be a breaking change to current users of `ImmutableUtil`.