### PR TITLE
Copy child context types when creating storeconnection

### DIFF
--- a/src/utils/connectToStores.js
+++ b/src/utils/connectToStores.js
@@ -89,6 +89,9 @@ function connectToStores(Spec, Component = Spec) {
       )
     }
   })
+  if (Component.contextTypes) {
+    StoreConnection.contextTypes = Component.contextTypes
+  }
 
   return StoreConnection
 }

--- a/test/connect-to-stores-test.js
+++ b/test/connect-to-stores-test.js
@@ -152,6 +152,40 @@ export default {
       assert.include(output, 'Foo: Bar')
     },
 
+    'component statics can see context properties'() {
+      const Child = connectToStores(React.createClass({
+        statics: {
+          getStores(props, context) {
+            return [context.store]
+          },
+          getPropsFromStores(props, context) {
+            return context.store.getState()
+          }
+        },
+        contextTypes: {
+          store: React.PropTypes.object
+        },
+        render() {
+          return <span>Foo: {this.props.foo}</span>
+        }
+      }))
+
+      const ContextComponent = React.createClass({
+        getChildContext() {
+          return { store: testStore }
+        },
+        childContextTypes: {
+          store: React.PropTypes.object
+        },
+        render() {
+          return <Child/>
+        }
+      })
+      const element = React.createElement(ContextComponent)
+      const output = React.renderToStaticMarkup(element)
+      assert.include(output, 'Foo: Bar')
+    },
+
     'component can get use stores from props'() {
       const LegacyComponent = React.createClass({
         statics: {


### PR DESCRIPTION
This makes using instances of alt by passing them through React context easier. StoreConnection doesn't have any contextTypes defined, so when it calls getStores/getPropsFromStore and passes in props/context, context will always be empty. To fix this, we can copy the contextTypes your component would've received, if it weren't wrapped, onto StoreConnection itself.