### PR TITLE
Copy contextTypes from component to StoreConnection in connectToStores

### DIFF
--- a/src/utils/connectToStores.js
+++ b/src/utils/connectToStores.js
@@ -57,6 +57,7 @@ function connectToStores(Spec, Component = Spec) {
 
   const StoreConnection = React.createClass({
     displayName: `Stateful${Component.displayName || Component.name || 'Container'}`,
+    contextTypes: Spec.contextTypes,
 
     getInitialState() {
       return Spec.getPropsFromStores(this.props, this.context)


### PR DESCRIPTION
Without this fix code like this doesn't work:
```js
@connectToStores
export default class Header extends React.Component {
  static contextTypes = {
    flux: React.PropTypes.any.isRequired
  }

  static getStores(props, context) {
    return [context.flux.getStore('application'), context.flux.getStore('cart')];
  }
}
```
...or is it better to separate the context of Component and StoreConnection?