### PR TITLE
Allow dispatching actions with action creators

### DIFF
--- a/src/alt/actions/index.js
+++ b/src/alt/actions/index.js
@@ -34,7 +34,7 @@ export default function makeAction(alt, namespace, name, implementation, obj) {
     // async functions that return promises should not be dispatched
     if (!newAction.dispatched && result !== undefined && !fn.isPromise(result)) {
       if (fn.isFunction(result)) {
-        result(dispatch)
+        result(dispatch, alt)
       } else {
         dispatch(result)
       }

--- a/src/alt/actions/index.js
+++ b/src/alt/actions/index.js
@@ -41,9 +41,12 @@ export default function makeAction(alt, namespace, name, implementation, obj) {
     }
 
     if (!newAction.dispatched && result === undefined) {
+      /* istanbul ignore else */
+      /*eslint-disable*/
       if (typeof console !== 'undefined') {
         console.warn('An action was called but nothing was dispatched')
       }
+      /*eslint-enable*/
     }
 
     return result

--- a/src/alt/actions/index.js
+++ b/src/alt/actions/index.js
@@ -39,6 +39,13 @@ export default function makeAction(alt, namespace, name, implementation, obj) {
         dispatch(result)
       }
     }
+
+    if (!newAction.dispatched && result === undefined) {
+      if (typeof console !== 'undefined') {
+        console.warn('An action was called but nothing was dispatched')
+      }
+    }
+
     return result
   }
   action.defer = (...args) => {

--- a/src/alt/index.js
+++ b/src/alt/index.js
@@ -34,15 +34,20 @@ class Alt {
         const actionId = action.id
         const namespace = actionId
         const name = actionId
+        const actionDetails = {
+          id: actionId,
+          namespace,
+          name,
+        }
+        const dispatchLater = payload => this.dispatch(actionId, payload, actionDetails)
+
+        if (fn.isFunction(dispatchData)) return dispatchData(dispatchLater)
+
         return this.dispatcher.dispatch({
           id,
           action: actionId,
           data: action.dispatch(data),
-          details: {
-            id: actionId,
-            namespace,
-            name,
-          }
+          details: actionDetails,
         })
       }
 

--- a/src/alt/index.js
+++ b/src/alt/index.js
@@ -26,6 +26,26 @@ class Alt {
   dispatch(action, data, details) {
     this.batchingFunction(() => {
       const id = Math.random().toString(18).substr(2, 16)
+
+      if (action.id && action.dispatch) {
+        const dispatchData = action.dispatch(data)
+        if (dispatchData === undefined) return
+
+        const actionId = action.id
+        const namespace = actionId
+        const name = actionId
+        return this.dispatcher.dispatch({
+          id,
+          action: actionId,
+          data: action.dispatch(data),
+          details: {
+            id: actionId,
+            namespace,
+            name,
+          }
+        })
+      }
+
       return this.dispatcher.dispatch({
         id,
         action,

--- a/src/alt/index.js
+++ b/src/alt/index.js
@@ -28,27 +28,7 @@ class Alt {
       const id = Math.random().toString(18).substr(2, 16)
 
       if (action.id && action.dispatch) {
-        const dispatchData = action.dispatch(data)
-        if (dispatchData === undefined) return
-
-        const actionId = action.id
-        const namespace = actionId
-        const name = actionId
-        const actionDetails = {
-          id: actionId,
-          namespace,
-          name,
-        }
-        const dispatchLater = payload => this.dispatch(actionId, payload, actionDetails)
-
-        if (fn.isFunction(dispatchData)) return dispatchData(dispatchLater, this)
-
-        return this.dispatcher.dispatch({
-          id,
-          action: actionId,
-          data: action.dispatch(data),
-          details: actionDetails,
-        })
+        return utils.dispatch(id, action, data, this)
       }
 
       return this.dispatcher.dispatch({

--- a/src/alt/index.js
+++ b/src/alt/index.js
@@ -41,7 +41,7 @@ class Alt {
         }
         const dispatchLater = payload => this.dispatch(actionId, payload, actionDetails)
 
-        if (fn.isFunction(dispatchData)) return dispatchData(dispatchLater)
+        if (fn.isFunction(dispatchData)) return dispatchData(dispatchLater, this)
 
         return this.dispatcher.dispatch({
           id,

--- a/src/alt/store/AltStore.js
+++ b/src/alt/store/AltStore.js
@@ -10,6 +10,7 @@ class AltStore {
     }
     this.state = state
 
+    this.alt = alt
     this.preventDefault = false
     this.displayName = model.displayName
     this.boundListeners = model.boundListeners

--- a/src/alt/utils/AltUtils.js
+++ b/src/alt/utils/AltUtils.js
@@ -1,3 +1,5 @@
+import * as fn from '../../utils/functions'
+
 /*eslint-disable*/
 const builtIns = Object.getOwnPropertyNames(NoopClass)
 const builtInProto = Object.getOwnPropertyNames(NoopClass.prototype)
@@ -42,6 +44,27 @@ export function formatAsConstant(name) {
 
 export function dispatchIdentity(x, ...a) {
   this.dispatch(a.length ? [x].concat(a) : x)
+}
+
+export function dispatch(id, actionObj, payload, alt) {
+  const data = actionObj.dispatch(payload)
+  if (data === undefined) return null
+
+  const type = actionObj.id
+  const namespace = type
+  const name = type
+  const details = { id: type, namespace, name }
+
+  const dispatchLater = x => alt.dispatch(type, x, details)
+
+  if (fn.isFunction(data)) return data(dispatchLater, alt)
+
+  return alt.dispatcher.dispatch({
+    id,
+    action: type,
+    data,
+    details,
+  })
 }
 
 /* istanbul ignore next */

--- a/test/index.js
+++ b/test/index.js
@@ -1420,6 +1420,68 @@ const tests = {
 
     assert(call.calledTwice, 'multiple action handlers are ok')
   },
+
+  'dispatching action creators'() {
+    const action = {
+      id: 'hello',
+      dispatch(data) {
+        return data
+      }
+    }
+
+    const alt = new Alt()
+
+    class Store {
+      constructor() {
+        this.bindAction(action, this.hello.bind(this))
+        this.state = { x: null }
+      }
+
+      hello(data) {
+        this.setState({ x: data })
+      }
+    }
+
+    const store = alt.createStore(Store)
+
+    assert(store.getState().x === null, 'x is null')
+
+    alt.dispatch(action, 3)
+
+    assert(store.getState().x === 3, '3 was dispatched')
+
+    alt.dispatch(action, 4)
+
+    assert(store.getState().x === 4, '4 was dispatched')
+
+    alt.dispatch(action, undefined)
+
+    assert(store.getState().x === 4, 'undefined means it wont dispatch')
+  },
+
+  'dispatching async action creators'(done) {
+    const action = {
+      id: 'hello',
+      dispatch(data) {
+        return dispatch => dispatch(done)
+      }
+    }
+
+    const alt = new Alt()
+
+    class Store {
+      constructor() {
+        this.bindAction(action, this.hello)
+      }
+
+      hello(done) {
+        done()
+      }
+    }
+
+    const store = alt.createStore(Store)
+    alt.dispatch(action)
+  },
 }
 
 export default tests


### PR DESCRIPTION
This allows the use of action creators which is good for using instances since now you can import actions directly and then just dispatch them.

```js
const increment = {
  id: 'my/increment/action',
  dispatch(x) {
    return x
  }
}

alt.dispatch(increment, 2) // will call my/increment/action with a payload of 2
```