### PR TITLE
remove babelrc

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,4 @@ npm-debug.log
 src
 test/browser/tests.js
 web
+.babelrc


### PR DESCRIPTION
Because there are different versions that contain different schema for a .babelrc file, it's probably best to avoid keeping this file in version control.