### PR TITLE
Remove this.dispatch usage from docs

### DIFF
--- a/docs/testing/actions.md
+++ b/docs/testing/actions.md
@@ -39,15 +39,17 @@ class PetActions {
         // adds import charge to cost
         totalCost = importCost + cost;
 
-    this.dispatch({
-      pet,
-      cost: totalCost
-    });
-
-    // checks if pet is legal
-    if(illegalAnimals.indexOf(pet) >= 0) {
-      legalActions.illegalPet(pet);
+    return (dispatch) => {
+      dispatch({
+        pet,
+        cost: totalCost
+      });
+      // checks if pet is legal
+      if(illegalAnimals.indexOf(pet) >= 0) {
+        legalActions.illegalPet(pet);
+      }
     }
+
   }
 }
 

--- a/guides/es5/index.md
+++ b/guides/es5/index.md
@@ -22,7 +22,7 @@ which is the equivalent to
 ```js
 var foodActions = alt.createActions(function () {
   this.addItem = function (item) {
-    this.dispatch(item);
+    return item;
   };
 });
 ```
@@ -32,7 +32,7 @@ or
 ```js
 var foodActions = alt.createActions({
   addItem: function (item) {
-    this.dispatch(item);
+    return item;
   }
 });
 ```
@@ -152,7 +152,7 @@ You can even create instances of alt if you prefer that over singletons. You wou
 // Actions
 var FoodActionsObject = {
   addItem: function (item) {
-    this.dispatch(item);
+    return item;
   }
 };
 

--- a/guides/getting-started/actions.md
+++ b/guides/getting-started/actions.md
@@ -22,7 +22,7 @@ var alt = require('../alt');
 
 class LocationActions {
   updateLocations(locations) {
-    this.dispatch(locations);
+    return locations;
   }
 }
 

--- a/web/_posts/2015-01-22-how-to-convert-flux-to-alt.md
+++ b/web/_posts/2015-01-22-how-to-convert-flux-to-alt.md
@@ -70,11 +70,11 @@ becomes something like this in alt:
 
 ```js
 clickThread: function(threadID) {
-  this.dispatch(threadID)
+  return threadID;
 }
 ```
 
-Having a function that wraps `this.dispatch` is kind of silly. If you don't need to do anything else in your action, meaning your action just passes through a value, you can use alt's `generateActions` shorthand in the constructor.
+ If you don't need to do anything else in your action, meaning your action just passes through a value, you can use alt's `generateActions` shorthand in the constructor.
 
 ```js
 // js/actions/ChatThreadActionCreators.js
@@ -101,10 +101,10 @@ Dispatch an Object containing the source or some sort of identifier.
 
 ```js
 receiveAll: function(rawMessages) {
-  this.dispatch({
+  return {
     source: 'server-action',
     data: rawMessages
-  });
+  };
 }
 ```
 
@@ -115,7 +115,7 @@ receiveAll: function(rawMessages) {
   // do things with rawMessages here
   log.debug(rawMessages);
 
-  this.dispatch(rawMessages);
+  return rawMessages;
 }
 ```
 
@@ -129,10 +129,11 @@ var ChatMessageDataUtils = require('../utils/ChatMessageDataUtils');
 
 class ChatMessageActions {
   createMessage(text) {
-    this.dispatch(text);
-
-    var message = ChatMessageDataUtils.getCreatedMessageData(text);
-    ChatWebAPIUtils.createMessage(message);
+    return (dispatch) => {
+      dispatch(text);
+      var message = ChatMessageDataUtils.getCreatedMessageData(text);
+      ChatWebAPIUtils.createMessage(message);
+    }
   }
 }
 ```


### PR DESCRIPTION
Together with #570 and #571, all usages of `this.dispatch` in the docs should be updated to use the new 0.18 syntax.