### PR TITLE
[fix]: issue with alt-devtool when in iframe

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -228,11 +228,12 @@ class Alt {
     return this.stores[name]
   }
 
-  static debug(name, alt) {
+  static debug(name, alt, win) {
     const key = 'alt.js.org'
-    if (typeof window !== 'undefined') {
-      window[key] = window[key] || []
-      window[key].push({ name, alt })
+    var win = win || window;
+    if (typeof win !== 'undefined') {
+      win[key] = win[key] || []
+      win[key].push({ name, alt })
     }
     return alt
   }

--- a/src/index.js
+++ b/src/index.js
@@ -230,9 +230,10 @@ class Alt {
 
   static debug(name, alt, win) {
     const key = 'alt.js.org'
-    if (typeof (win || window) !== 'undefined') {
-      (win || window)[key] = (win || window)[key] || []
-      (win || window)[key].push({name, alt})
+    let context = win || window
+    if (typeof context !== 'undefined') {
+      context[key] = context[key] || []
+      context[key].push({name, alt})
     }
     return alt
   }

--- a/src/index.js
+++ b/src/index.js
@@ -230,7 +230,7 @@ class Alt {
 
   static debug(name, alt, win) {
     const key = 'alt.js.org'
-    var win = win || window;
+    let win = win || window;
     if (typeof win !== 'undefined') {
       win[key] = win[key] || []
       win[key].push({ name, alt })

--- a/src/index.js
+++ b/src/index.js
@@ -230,7 +230,7 @@ class Alt {
 
   static debug(name, alt, win) {
     const key = 'alt.js.org'
-    let win = win || window;
+    win = win || window
     if (typeof win !== 'undefined') {
       win[key] = win[key] || []
       win[key].push({ name, alt })

--- a/src/index.js
+++ b/src/index.js
@@ -230,7 +230,10 @@ class Alt {
 
   static debug(name, alt, win) {
     const key = 'alt.js.org'
-    const context = win || window
+    const context = win
+    if(!context && typeof window !== 'undefined') {
+      context = window
+    }
     if (typeof context !== 'undefined') {
       context[key] = context[key] || []
       context[key].push({ name, alt })

--- a/src/index.js
+++ b/src/index.js
@@ -230,7 +230,6 @@ class Alt {
 
   static debug(name, alt, win) {
     const key = 'alt.js.org'
-    win = win || window
     if (typeof (win || window) !== 'undefined') {
       (win || window)[key] = (win || window)[key] || []
       (win || window)[key].push({name, alt})

--- a/src/index.js
+++ b/src/index.js
@@ -230,8 +230,8 @@ class Alt {
 
   static debug(name, alt, win) {
     const key = 'alt.js.org'
-    const context = win
-    if(!context && typeof window !== 'undefined') {
+    let context = win
+    if (!context && typeof window !== 'undefined') {
       context = window
     }
     if (typeof context !== 'undefined') {

--- a/src/index.js
+++ b/src/index.js
@@ -231,9 +231,9 @@ class Alt {
   static debug(name, alt, win) {
     const key = 'alt.js.org'
     win = win || window
-    if (typeof win !== 'undefined') {
-      win[key] = win[key] || []
-      win[key].push({ name, alt })
+    if (typeof (win || window) !== 'undefined') {
+      (win || window)[key] = (win || window)[key] || []
+      (win || window)[key].push({name, alt})
     }
     return alt
   }

--- a/src/index.js
+++ b/src/index.js
@@ -230,10 +230,10 @@ class Alt {
 
   static debug(name, alt, win) {
     const key = 'alt.js.org'
-    let context = win || window
+    const context = win || window
     if (typeof context !== 'undefined') {
       context[key] = context[key] || []
-      context[key].push({name, alt})
+      context[key].push({ name, alt })
     }
     return alt
   }


### PR DESCRIPTION
Fix for an issue with alt-devtool extension when the Alt.debug function is called from an iframe, added win argument to allow for the root window to be passed in.