### PR TITLE
Remove broken example links from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -809,11 +809,6 @@ flux.getActions('myActions');
 
 To help facilitate with isomorphism alt recommends you use [iso](https://github.com/goatslacker/iso), a helper function which serializes the data on the server into markup and then parses that data back into usable JavaScript on the client. Iso is a great complement to alt for a full-stack flux approach.
 
-## Examples
-
-* [todomvc](https://github.com/goatslacker/alt/blob/master/examples/todomvc)
-* [chat](https://github.com/goatslacker/alt/tree/master/examples/chat)
-
 ## Converting a flux application to alt
 
 1. [Importing the chat project](https://github.com/goatslacker/alt/commit/1a54de1064fe5bd252979380e47b0409d1306773).


### PR DESCRIPTION
This removes a pair of broken links to examples that no longer exist in this repository. These examples were removed in this commit https://github.com/goatslacker/alt/commit/f365116db93b899f92c676eebfc21a167655c5d1