### PR TITLE
Updating documentation on connectToStores alt util

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,14 +67,16 @@ class TodoStore {
 export default alt.createStore(TodoStore, 'TodoStore');
 ```
 
-View
+View 
+
+Using the [connectToStores](https://github.com/altjs/utils/blob/master/src/connectToStores.js) util from [alt-utils](https://github.com/altjs/utils) package (`npm install alt-utils`)
 
 ```js
-import connectToStores from 'alt/utils/connectToStores';
+// ES2015 (ES6)
+import connectToStores from 'alt-utils/lib/connectToStores';
 import { Component } from 'react';
 import TodoStore from './TodoStore';
 
-@connectToStores
 class TodoView extends Component {
   static getStores() {
     return [TodoStore];
@@ -95,6 +97,27 @@ class TodoView extends Component {
       </ul>
     );
   }
+}
+export default connectToStores(TodoView);
+```
+or
+```js
+//ES2016 (ES7) using @connectToStores Decorator
+import connectToStores from 'alt-utils/lib/connectToStores';
+import { Component } from 'react';
+import TodoStore from './TodoStore';
+
+@connectToStores
+class TodoView extends Component {
+  static getStores() {
+    return [TodoStore];
+  }
+
+  static getPropsFromStores() {
+    return TodoStore.getState();
+  }
+
+  ...
 }
 ```
 


### PR DESCRIPTION
I noticed that since installing 0.18.1 that the utils have now been removed.

The documentation has fallen behind a little with regards to the `View` section when it comes `connectToStores` so I have updated to let users know to install the `alt-utils` package and get connectToStores from there.

Also, when I was trying to use alt.js for the first time I was having problems with the fact the View example was using the ES7 `@connectToStore` decorator which really threw me off as I hadn't looked at any ES7 features and had no idea what to search for to find why it wasn't working for me.  So I updated it to include ES6 and ES7 examples