### PR TITLE
Linking to bootstrap doc page from takeSnapshot

### DIFF
--- a/docs/takeSnapshot.md
+++ b/docs/takeSnapshot.md
@@ -11,10 +11,11 @@ permalink: /docs/takeSnapshot/
 
 Take snapshot provides you with the entire application's state serialized to JSON, by default, but you may also pass in stores to take a snapshot of a subset of the application's state.
 
-Snapshots are a core component of alt. The idea is that at any given point in time you can `takeSnapshot` and have your entire application's state
-serialized for persistence, transferring, logging, or debugging.
+Snapshots are a core component of alt. The idea is that at any given point in time you can `takeSnapshot` and have your entire application's state serialized for persistence, transferring, logging, or debugging.
 
 ```js
 var snapshot = alt.takeSnapshot();
 var partialSnapshot = alt.takeSnapshot(Store1, Store3);
 ```
+
+You can bootstrap a snapshot into your application using [`alt.bootstrap`](bootstrap.md)


### PR DESCRIPTION
I thought this might be useful for newcomers to alt, as it shows the relation between the two methods.

Open to suggestions on how to improve this though.