### PR TITLE
Fix dev deps so that the build doesn`t break after the initial setup.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "babel-cli": "6.3.17",
     "babel-core": "6.3.17",
     "babel-eslint": "5.0.0-beta6",
+    "babel-loader": "^6.2.1",
     "babel-plugin-external-helpers-2": "6.3.13",
     "babel-preset-airbnb": "1.0.1",
     "babel-preset-stage-0": "6.3.13",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react-dom": "0.14.0",
     "rimraf": "^2.3.2",
     "sinon": "^1.14.0",
+    "style-loader": "^0.13.0",
     "webpack": "^1.9.12"
   },
   "repository": {


### PR DESCRIPTION
After checking out the source code for the first time and `npm install` the error was being displayed:

<img width="643" alt="screen shot 2016-01-25 at 20 10 00" src="https://cloud.githubusercontent.com/assets/613647/12561302/aecba48c-c39f-11e5-99f9-f14e8682f58f.png">

The reason was a missing `babel-loader` and `style-loader` dependency. This should be gone with this PR merged in.
