### PR TITLE
Fix module exports.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,6 @@
 {
-  "presets": ["airbnb", "stage-0"]
+  "presets": ["airbnb", "stage-0"],
+  "plugins": [
+    "add-module-exports"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "babel-cli": "6.3.17",
     "babel-core": "6.3.17",
     "babel-eslint": "5.0.0-beta6",
+    "babel-plugin-add-module-exports": "^0.1.2",
     "babel-plugin-external-helpers-2": "6.3.13",
     "babel-preset-airbnb": "1.0.1",
     "babel-preset-stage-0": "6.3.13",


### PR DESCRIPTION
Starting with Babel 6 and onwards, Babel [no longer exports](http://stackoverflow.com/a/34778391/596625) libraries under `module.exports` which is breaking our builds. There's a neat plugin that fixes the behavior. 