### PR TITLE
Removed dispatch from typings

### DIFF
--- a/typings/alt/alt.d.ts
+++ b/typings/alt/alt.d.ts
@@ -87,7 +87,6 @@ declare module AltJS {
 
   export interface ActionsClass {
     generateActions?( ...action:Array<string>):void;
-    dispatch( ...payload:Array<any>):void;
     actions?:Actions;
   }
 


### PR DESCRIPTION
Apparently new Alt version ( 0.18.x ) removed `dispatch` from Actions.