### PR TITLE
getPrototypeChain gets whole prototype chain

### DIFF
--- a/src/utils/AltUtils.js
+++ b/src/utils/AltUtils.js
@@ -7,7 +7,7 @@ const builtInProto = Object.getOwnPropertyNames(NoopClass.prototype)
 
 export function getInternalMethods(Obj, isProto) {
   const excluded = isProto ? builtInProto : builtIns
-  const obj = isProto ? Obj.prototype : Obj
+  const obj = isProto && typeof Obj === 'function' ? Obj.prototype : Obj
   return Object.getOwnPropertyNames(obj).reduce((value, m) => {
     if (excluded.indexOf(m) !== -1) {
       return value
@@ -19,10 +19,10 @@ export function getInternalMethods(Obj, isProto) {
 }
 
 export function getPrototypeChain(Obj, methods = {}) {
-  return Obj === Function.prototype
+  return Obj === Object.prototype
     ? methods
     : getPrototypeChain(
-        Object.getPrototypeOf(Obj),
+        Object.getPrototypeOf((typeof Obj === 'function') ? Obj.prototype : Obj),
         fn.assign(getInternalMethods(Obj, true), methods)
       )
 }


### PR DESCRIPTION
Hi,

this changes `AltUtils.getPrototypeChain` to return methods from the whole prototype chain (instead of just from the first prototype), which we needed since we have multiple subclasses in the chain for the final `ActionClass`.

I'm not sure you guys want something like that merged, but in case you do here's the patch.

Thanks for the feedback
