### PR TITLE
fix problem with referring this in async action after codemod

### DIFF
--- a/scripts/this-dispatch-to-return.js
+++ b/scripts/this-dispatch-to-return.js
@@ -39,8 +39,7 @@ const replaceFunction = (j, p) => {
     p.value.params,
     j.blockStatement([
       j.returnStatement(
-        j.functionExpression(
-          null,
+        j.arrowFunctionExpression(
           [j.identifier('dispatch')],
           j.blockStatement(p.value.body.body)
         )


### PR DESCRIPTION
Changes this

``` js
class SomeActions {
  foo(data) {
    return function(dispatch) {
      dispatch(data);
      this.bar(); // broken
    };
  }

  bar() {}
}
```

to this

``` js
class SomeActions {
  foo(data) {
    return dispatch => {
      dispatch(data);
      this.bar(); // everything work fine
    };
  }

  bar() {}
}
```
