### PR TITLE
Fixing issues with babel core on a fresh install and addressing batch test failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "alt-search-docs": "1.0.6",
     "babel-cli": "6.6.5",
-    "babel-core": "6.7.4",
+    "babel-core": "6.21.0",
     "babel-eslint": "5.0.0",
     "babel-loader": "6.2.4",
     "babel-plugin-add-module-exports": "^0.1.2",

--- a/test/batching-test.js
+++ b/test/batching-test.js
@@ -6,12 +6,13 @@ import sinon from 'sinon'
 import TestUtils from 'react-addons-test-utils'
 import ReactDom from 'react-dom'
 
-// TOOD action was called but not dispatched?
 const Actions = {
   buttonClick() {
     setTimeout(() => {
       this.switchComponent()
     }, 10)
+
+    return null
   },
 
   switchComponent() {


### PR DESCRIPTION
Running into this issue when running a new 'npm intall':

```
TypeError: Path must be a string. Received undefined
    at assertPath (path.js:7:11)
    at Object.dirname (path.js:1324:5)
    at /Users/jdollar/personalrepos/alt/node_modules/babel-core/lib/transformation/file/options/option-manager.js:353:36
    at /Users/jdollar/personalrepos/alt/node_modules/babel-core/lib/transformation/file/options/option-manager.js:375:22
    at Array.map (native)
    at OptionManager.resolvePresets (/Users/jdollar/personalrepos/alt/node_modules/babel-core/lib/transformation/file/options/option-manager.js:364:20)
    at OptionManager.mergePresets (/Users/jdollar/personalrepos/alt/node_modules/babel-core/lib/transformation/file/options/option-manager.js:348:10)
    at OptionManager.mergeOptions (/Users/jdollar/personalrepos/alt/node_modules/babel-core/lib/transformation/file/options/option-manager.js:307:14)
    at /Users/jdollar/personalrepos/alt/node_modules/babel-core/lib/transformation/file/options/option-manager.js:349:14
    at /Users/jdollar/personalrepos/alt/node_modules/babel-core/lib/transformation/file/options/option-manager.js:369:24
```

The package.json babel-core upgrade came from these:
Original issue with the fix: https://github.com/webpack/webpack/issues/2463
Linked issue in babel-core: https://github.com/babel/babel/issues/4306

In addition to the install failing there were also two tests failing for the batch dispatch tests. Had a "TODO" comment stating nothing was getting dispatched and the error I was getting was:

```
ReferenceError: An action was called but nothing was dispatched-_-_-_-_-_-_-_-_-_-_,------,
    at Object.warn (/Users/jdollar/personalrepos/alt/lib/utils/AltUtils.js:52:18)-_|   /\_/\
    at Object.action [as buttonClick] (/Users/jdollar/personalrepos/alt/lib/actions/index.js:54:13)
    at Context.doesNotBatch (/Users/jdollar/personalrepos/alt/test/batching-test.js:93:27)
    at callFnAsync (/Users/jdollar/personalrepos/alt/node_modules/mocha/lib/runnable.js:349:8)
    at Test.Runnable.run (/Users/jdollar/personalrepos/alt/node_modules/mocha/lib/runnable.js:301:7)
    at Runner.runTest (/Users/jdollar/personalrepos/alt/node_modules/mocha/lib/runner.js:422:10)
    at /Users/jdollar/personalrepos/alt/node_modules/mocha/lib/runner.js:528:12
    at next (/Users/jdollar/personalrepos/alt/node_modules/mocha/lib/runner.js:342:14)
    at /Users/jdollar/personalrepos/alt/node_modules/mocha/lib/runner.js:352:7
    at next (/Users/jdollar/personalrepos/alt/node_modules/mocha/lib/runner.js:284:14)
    at /Users/jdollar/personalrepos/alt/node_modules/mocha/lib/runner.js:315:7
    at done (/Users/jdollar/personalrepos/alt/node_modules/mocha/lib/runnable.js:287:5)
    at callFn (/Users/jdollar/personalrepos/alt/node_modules/mocha/lib/runnable.js:344:7)
    at Hook.Runnable.run (/Users/jdollar/personalrepos/alt/node_modules/mocha/lib/runnable.js:319:7)
    at next (/Users/jdollar/personalrepos/alt/node_modules/mocha/lib/runner.js:298:10)
    at Immediate.<anonymous> (/Users/jdollar/personalrepos/alt/node_modules/mocha/lib/runner.js:320:5)
    at runCallback (timers.js:649:20)
    at tryOnImmediate (timers.js:622:5)
    at processImmediate [as _immediateCallback] (timers.js:594:5)
ReferenceError: An action was called but nothing was dispatched-_-_-_-_-_-_-_-_-_-__,------,
    at Object.warn (/Users/jdollar/personalrepos/alt/lib/utils/AltUtils.js:52:18)-__|  /\_/\
    at Object.action [as buttonClick] (/Users/jdollar/personalrepos/alt/lib/actions/index.js:54:13)
    at Context.allowsBatching (/Users/jdollar/personalrepos/alt/test/batching-test.js:107:27)
    at callFnAsync (/Users/jdollar/personalrepos/alt/node_modules/mocha/lib/runnable.js:349:8)
    at Test.Runnable.run (/Users/jdollar/personalrepos/alt/node_modules/mocha/lib/runnable.js:301:7)
    at Runner.runTest (/Users/jdollar/personalrepos/alt/node_modules/mocha/lib/runner.js:422:10)
    at /Users/jdollar/personalrepos/alt/node_modules/mocha/lib/runner.js:528:12
    at next (/Users/jdollar/personalrepos/alt/node_modules/mocha/lib/runner.js:342:14)
    at /Users/jdollar/personalrepos/alt/node_modules/mocha/lib/runner.js:352:7
    at next (/Users/jdollar/personalrepos/alt/node_modules/mocha/lib/runner.js:284:14)
    at /Users/jdollar/personalrepos/alt/node_modules/mocha/lib/runner.js:315:7
    at done (/Users/jdollar/personalrepos/alt/node_modules/mocha/lib/runnable.js:287:5)
    at callFn (/Users/jdollar/personalrepos/alt/node_modules/mocha/lib/runnable.js:344:7)
    at Hook.Runnable.run (/Users/jdollar/personalrepos/alt/node_modules/mocha/lib/runnable.js:319:7)
    at next (/Users/jdollar/personalrepos/alt/node_modules/mocha/lib/runner.js:298:10)
    at Immediate.<anonymous> (/Users/jdollar/personalrepos/alt/node_modules/mocha/lib/runner.js:320:5)
    at runCallback (timers.js:649:20)
    at tryOnImmediate (timers.js:622:5)
    at processImmediate [as _immediateCallback] (timers.js:594:5)
```

Updated the batch test file to just dispatch a null in addition to getting dispatched from the timeout.
