### PR TITLE
Silence warning when no data is dispatched as payload for an action

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -26,7 +26,7 @@ export default function makeAction(alt, namespace, name, implementation, obj) {
     }
 
     if (invocationResult === undefined) {
-      utils.warn('An action was called but nothing was dispatched')
+      // An action was called but nothing was dispatched
     }
 
     return actionResult


### PR DESCRIPTION
I often use an Alt action for sending events. For example, I might dispatch the `pressXYButton()` while declaring the animation for that button. I find payloadless dispatch useful because it reinforces the idea that all data passes through the stores.

Currently, Alt warns if an action doesn't return data. This silences that warning. 

See #506